### PR TITLE
Fix permission issues without Docker BuildKit

### DIFF
--- a/ros2_ws/Dockerfile
+++ b/ros2_ws/Dockerfile
@@ -5,7 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 COPY config/apt-key /tmp/apt-key
 RUN apt-key add /tmp/apt-key
 
-RUN apt update && apt install -y \
+RUN apt-get update && apt-get install -y \
   autoconf \
   automake \
   build-essential \
@@ -48,7 +48,7 @@ ENV HOME /home/${USER}
 ARG UID=1000
 ARG GID=1000
 RUN addgroup --gid ${GID} ${USER}
-RUN adduser --gecos "ROS User" --uid ${UID} --gid ${GID} ${USER} && yes | passwd ${USER}
+RUN adduser --gecos "ROS2 User" --uid ${UID} --gid ${GID} ${USER} && yes | passwd ${USER}
 RUN usermod -a -G dialout ${USER}
 RUN echo "${USER} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/99_aptget
 RUN chmod 0440 /etc/sudoers.d/99_aptget && chown root:root /etc/sudoers.d/99_aptget
@@ -60,8 +60,8 @@ RUN chmod 744 /sshd_entrypoint.sh
 
 # build ROS workspace
 USER ${USER}
+RUN mkdir -p ${HOME}/ros2_ws/src
 WORKDIR ${HOME}/ros2_ws/
-RUN mkdir -p src
 RUN rosdep update
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 RUN /bin/bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash; colcon build --symlink-install"

--- a/ros_ws/Dockerfile
+++ b/ros_ws/Dockerfile
@@ -2,7 +2,7 @@ ARG ROS_DISTRO=noetic
 FROM ros:${ROS_DISTRO} as base-dependencies
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt update && apt install -y \
+RUN apt-get update && apt-get install -y \
   autoconf \
   automake \
   build-essential \
@@ -29,8 +29,6 @@ RUN apt update && apt install -y \
   sudo \
   unzip \
   && rm -rf /var/lib/apt/lists/*
-
-RUN sudo rosdep update
 
 RUN echo "Set disable_coredump false" >> /etc/sudo.conf
 
@@ -63,8 +61,9 @@ RUN chmod 744 /sshd_entrypoint.sh
 
 # build ROS workspace
 USER ${USER}
+RUN mkdir -p ${HOME}/ros_ws/src
 WORKDIR ${HOME}/ros_ws/
-RUN mkdir -p src
+RUN rosdep update
 ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 RUN /bin/bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash; catkin_make"
 


### PR DESCRIPTION
So I was trying to build the images without `DOCKER_BUILDKIT=1` in the build scripts and I ran into some permission issues. My interpretation is that `WORKDIR ros_ws` creates and sets the new directory but without the buildkit, it has the wrong permissions, so the user is not able to create another directory there. By creating the directory before setting the WORKDIR, this issue can be avoided and the image can be built without the buildkit. 
I was trying that out because of the CI that we want to do and github actions don't know the buildkit. What do you think?