### PR TITLE
Build and push ROS images in CI

### DIFF
--- a/.github/actions/build-push/action.yml
+++ b/.github/actions/build-push/action.yml
@@ -19,7 +19,7 @@ runs:
         ROS_DISTRO=${IMAGE_NAME#*:}
         WORKSPACE=${IMAGE_ID#*/}
         WORKSPACE=${WORKSPACE/-/_}
-        docker build ${WORKSPACE} --file ${WORKSPACE}/Dockerfile  --build-arg ROS_DISTRO=${ROS_DISTRO} --tag ${IMAGE_ID} --label "runnumber=${GITHUB_RUN_ID}"
+        docker build ${WORKSPACE} --file ${WORKSPACE}/Dockerfile  --build-arg ROS_DISTRO=${ROS_DISTRO} --tag ${IMAGE_ID}
       shell: bash
 
     - name: Login to GitHub Container Registry

--- a/.github/actions/build-push/action.yml
+++ b/.github/actions/build-push/action.yml
@@ -1,0 +1,35 @@
+name: 'Build and Push'
+description: 'Build the Docker image and push to GitHub Container Registry'
+inputs:
+  image:
+    description: 'The desired image'
+    required: false
+    default: 'aica-technology/ros2-ws:foxy'
+  secret:
+    description: 'GitHub Container Registry secret'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Build image
+      run: |
+        IMAGE_NAME=${{ inputs.image }}
+        IMAGE_ID=${IMAGE_NAME%:*}
+        ROS_DISTRO=${IMAGE_NAME#*:}
+        WORKSPACE=${IMAGE_ID#*/}
+        WORKSPACE=${WORKSPACE/-/_}
+        docker build ${WORKSPACE} --file ${WORKSPACE}/Dockerfile  --build-arg ROS_DISTRO=${ROS_DISTRO} --tag ${IMAGE_ID} --label "runnumber=${GITHUB_RUN_ID}"
+      shell: bash
+
+    - name: Login to GitHub Container Registry
+      run: echo "${{ inputs.secret }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+      shell: bash
+
+    - name: Push image
+      run: |
+        IMAGE_NAME=${{ inputs.image }}
+        IMAGE_ID=${IMAGE_NAME%:*}
+        docker tag ${IMAGE_ID} ghcr.io/${IMAGE_NAME}
+        docker push ghcr.io/${IMAGE_NAME}
+      shell: bash

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -1,0 +1,36 @@
+name: Build and Push
+
+# Run workflow on pushes to master branch or by manual dispatch
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+
+  build-publish-noetic:
+    runs-on: ubuntu-latest
+    name: Build and publish ROS noetic image
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Build and Push
+        uses: ./.github/actions/build-push
+        with:
+          image: aica-technology/ros-ws:noetic
+          secret: ${{ secrets.CR_PAT }}
+
+  build-publish-foxy:
+    runs-on: ubuntu-latest
+    name: Build and publish ROS2 foxy image
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Build and Push
+        uses: ./.github/actions/build-push
+        with:
+          image: aica-technology/ros2-ws:foxy
+          secret: ${{ secrets.CR_PAT }}

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -4,7 +4,7 @@ name: Build and Push
 on:
   push:
     branches:
-      - master
+      - main
   workflow_dispatch:
 
 jobs:
@@ -20,7 +20,7 @@ jobs:
         uses: ./.github/actions/build-push
         with:
           image: aica-technology/ros-ws:noetic
-          secret: ${{ secrets.CR_PAT }}
+          secret: ${{ secrets.GITHUB_TOKEN }}
 
   build-publish-foxy:
     runs-on: ubuntu-latest
@@ -33,4 +33,4 @@ jobs:
         uses: ./.github/actions/build-push
         with:
           image: aica-technology/ros2-ws:foxy
-          secret: ${{ secrets.CR_PAT }}
+          secret: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/manual_dispatch.yml
+++ b/.github/workflows/manual_dispatch.yml
@@ -20,4 +20,4 @@ jobs:
         uses: ./.github/actions/build-push
         with:
           image: ${{ github.event.inputs.image }}
-          secret: ${{ secrets.CR_PAT }}
+          secret: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/manual_dispatch.yml
+++ b/.github/workflows/manual_dispatch.yml
@@ -1,0 +1,23 @@
+name: Manual Build and Push
+
+# Run workflow by manual dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      image:
+        description: 'The desired image (aica-technology/<ros_workspace>:<ros_distro>)'
+        required: true
+
+jobs:
+  build-publish:
+    runs-on: ubuntu-latest
+    name: Build and publish ROS image
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v2
+
+      - name: Build and Push
+        uses: ./.github/actions/build-push
+        with:
+          image: ${{ github.event.inputs.image }}
+          secret: ${{ secrets.CR_PAT }}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 ### ROS workspace
 
 The ros_ws image provides a ROS workspace.
-Build it by running the [build script](ros_ws/build.sh) script while
+Build it by running the [build script](ros_ws/build.sh) while
 in the [ros_ws](ros_ws) directory. Modify the ROS distribution in
 the script as desired.
 
@@ -16,7 +16,7 @@ The username that should be supplied at login is `ros`.
 ### ROS2 workspace
 
 Similar to the ROS workspace, the ros2_ws image provides a ROS2 workspace.
-Build it by running the [build script](ros2_ws/build.sh) script while
+Build it by running the [build script](ros2_ws/build.sh) while
 in the [ros2_ws](ros2_ws) directory. Modify the ROS2 distribution
 in the script as desired.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # docker_images
 
+![Build and Push ROS and ROS2 images](https://github.com/aica-technology/docker-images/actions/workflows/build-push.yml/badge.svg)
+
 ## Images
 
 ### ROS workspace


### PR DESCRIPTION
This PR adds two workflows, one to build and push the noetic and foxy image upon push on main and one that can be manually dispatched with a desired configuration as input (e.g. starting the workflow with `aica-technology/ros2_ws:galactic` will build a ros2 galactic image). It uses the `secrects.GITHUB_TOKEN` to have write and read permissions, so no other secret is needed. It will also automatically connect the packages to the repository (obviously, as it is now the repo that creates and pushes the package and not the user).