### PR TITLE
Fix RViz warnings and add Nano to images

### DIFF
--- a/ros2_ws/Dockerfile
+++ b/ros2_ws/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -y \
   libssl-dev \
   make \
   mesa-utils \
+  nano \
   python3-setuptools \
   python3-pip \
   ros-${ROS_DISTRO}-rviz2 \

--- a/ros_ws/Dockerfile
+++ b/ros_ws/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
   libssl-dev \
   make \
   mesa-utils \
+  nano \
   python3-setuptools \
   python3-pip \
   python3-rosdep \

--- a/scripts/run_interactive.sh
+++ b/scripts/run_interactive.sh
@@ -66,6 +66,7 @@ else
   RUN_FLAGS+=(-e DISPLAY="${DISPLAY}")
   RUN_FLAGS+=(-e XAUTHORITY="${XAUTHORITY}")
   RUN_FLAGS+=(-v /tmp/.X11-unix:/tmp/.X11-unix:rw)
+  RUN_FLAGS+=(--device=/dev/dri:/dev/dri)
 fi
 
 docker run -it --rm \

--- a/scripts/server.sh
+++ b/scripts/server.sh
@@ -86,6 +86,7 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
   COMMAND_FLAGS+=(--gid "${GROUP_ID}")
 
   RUN_FLAGS+=(--volume=/tmp/.X11-unix:/tmp/.X11-unix:rw)
+  RUN_FLAGS+=(--device=/dev/dri:/dev/dri)
 fi
 
 docker container stop "$CONTAINER_NAME" >/dev/null 2>&1


### PR DESCRIPTION
As discussed, adding `--device=/dev/dri:/dev/dri` in the docker commands resolves some warnings with RViz. I propose to merge that solution now and if problems come up again or we can solve the Mac issues, we do that in another PR.

Additionally, I added nano to the workspace images, that was another TODO that we had.