### PR TITLE
Add GPU option

### DIFF
--- a/scripts/run_interactive.sh
+++ b/scripts/run_interactive.sh
@@ -3,6 +3,7 @@
 IMAGE_NAME=""
 CONTAINER_NAME=""
 USERNAME=""
+GPUS=""
 
 HELP_MESSAGE="
 Usage: ./run_interactive.sh <image> [-n <name>] [-u <user>]
@@ -28,6 +29,11 @@ Options:
                            mount between the host and container
                            as two full paths separated by a ':'.
 
+  --gpus <gpus_options>    Add GPU access for applications that
+                           require hardware acceleration (e.g. Gazebo)
+                           For the list of gpus_options parameters
+                           see https://docs.docker.com/config/containers/resource_constraints/
+
   -h, --help               Show this help message."
 
 
@@ -38,28 +44,36 @@ while [ "$#" -gt 0 ]; do
     -n|--name) CONTAINER_NAME=$2; shift 2;;
     -u|--user) USERNAME=$2; shift 2;;
     -v|--volume) RUN_FLAGS+=(-v "$2"); shift 2;;
+    --gpus) GPUS=$2; shift 2;;
     -h|--help) echo "${HELP_MESSAGE}"; exit 0;;
     -*) echo "Unknown option: $1" >&2; echo "${HELP_MESSAGE}"; exit 1;;
     *) IMAGE_NAME=$1; shift 1;;
   esac
 done
 
-if [ -z "$IMAGE_NAME" ]; then
+if [ -z "${IMAGE_NAME}" ]; then
   echo "No image name provided!"
   echo "${HELP_MESSAGE}"
   exit 1
 fi
 
-if [ -z "$CONTAINER_NAME" ]; then
+if [ -z "${CONTAINER_NAME}" ]; then
   CONTAINER_NAME="${IMAGE_NAME/\//-}"
   CONTAINER_NAME="${CONTAINER_NAME/:/-}-runtime"
 fi
 
-if [ -n "$USERNAME" ]; then
+if [ -n "${USERNAME}" ]; then
   RUN_FLAGS+=(-u "${USERNAME}")
 fi
 
-if [[ "$OSTYPE" == "darwin"* ]]; then
+if [ -n "${GPUS}" ]; then
+  RUN_FLAGS+=(--gpus "${GPUS}")
+  RUN_FLAGS+=(--env DISPLAY="${DISPLAY}")
+  RUN_FLAGS+=(--env NVIDIA_VISIBLE_DEVICES="${NVIDIA_VISIBLE_DEVICES:-all}")
+  RUN_FLAGS+=(--env NVIDIA_DRIVER_CAPABILITIES="${NVIDIA_DRIVER_CAPABILITIES:+$NVIDIA_DRIVER_CAPABILITIES,}graphics")
+fi
+
+if [[ "${OSTYPE}" == "darwin"* ]]; then
   RUN_FLAGS+=(-e DISPLAY=host.docker.internal:0)
 else
   xhost +

--- a/scripts/run_interactive.sh
+++ b/scripts/run_interactive.sh
@@ -29,9 +29,9 @@ Options:
                            mount between the host and container
                            as two full paths separated by a ':'.
 
-  --gpus <gpus_options>    Add GPU access for applications that
+  --gpus <gpu_options>     Add GPU access for applications that
                            require hardware acceleration (e.g. Gazebo)
-                           For the list of gpus_options parameters
+                           For the list of gpu_options parameters
                            see https://docs.docker.com/config/containers/resource_constraints/
 
   -h, --help               Show this help message."

--- a/scripts/server.sh
+++ b/scripts/server.sh
@@ -45,9 +45,9 @@ Options:
   -u, --user <user>        Specify the name of the remote user.
                            (default: ${USERNAME})
 
-  --gpus <gpus_options>    Add GPU access for applications that
+  --gpus <gpu_options>     Add GPU access for applications that
                            require hardware acceleration (e.g. Gazebo)
-                           For the list of gpus_options parameters
+                           For the list of gpu_options parameters
                            see https://docs.docker.com/config/containers/resource_constraints/
 
   -h, --help               Show this help message."

--- a/scripts/server.sh
+++ b/scripts/server.sh
@@ -4,6 +4,7 @@ SSH_PORT=3333
 SSH_KEY_FILE="$HOME/.ssh/id_rsa.pub"
 IMAGE_NAME=""
 USERNAME=root
+GPUS=""
 
 HELP_MESSAGE="
 Usage: ./server.sh <image> [-p <port>] [-k <file>] [-n <name>] [-u <user>]
@@ -44,6 +45,11 @@ Options:
   -u, --user <user>        Specify the name of the remote user.
                            (default: ${USERNAME})
 
+  --gpus <gpus_options>    Add GPU access for applications that
+                           require hardware acceleration (e.g. Gazebo)
+                           For the list of gpus_options parameters
+                           see https://docs.docker.com/config/containers/resource_constraints/
+
   -h, --help               Show this help message."
 
 CONTAINER_NAME=""
@@ -55,6 +61,7 @@ while [ "$#" -gt 0 ]; do
     -i|--image) IMAGE_NAME=$2; shift 2;;
     -n|--name) CONTAINER_NAME=$2; shift 2;;
     -u|--user) USERNAME=$2; shift 2;;
+    --gpus) GPUS=$2; shift 2;;
     -h|--help) echo "${HELP_MESSAGE}"; exit 0;;
     -*) echo "Unknown option: $1" >&2; echo "${HELP_MESSAGE}"; exit 1;;
     *) IMAGE_NAME=$1; shift 1;;
@@ -87,6 +94,13 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
 
   RUN_FLAGS+=(--volume=/tmp/.X11-unix:/tmp/.X11-unix:rw)
   RUN_FLAGS+=(--device=/dev/dri:/dev/dri)
+fi
+
+if [ -n "${GPUS}" ]; then
+  RUN_FLAGS+=(--gpus "${GPUS}")
+  RUN_FLAGS+=(--env DISPLAY="${DISPLAY}")
+  RUN_FLAGS+=(--env NVIDIA_VISIBLE_DEVICES="${NVIDIA_VISIBLE_DEVICES:-all}")
+  RUN_FLAGS+=(--env NVIDIA_DRIVER_CAPABILITIES="${NVIDIA_DRIVER_CAPABILITIES:+$NVIDIA_DRIVER_CAPABILITIES,}graphics")
 fi
 
 docker container stop "$CONTAINER_NAME" >/dev/null 2>&1


### PR DESCRIPTION
This PR adds the `--gpus` option to the `run_interactive.sh` script. It basically forward the option to the docker engine to respect docker options for GPU usage. Most common usage will be `--gpus all`.

When the `--gpus` flag is set, it also set the `nvidia` environment variables. This avoids having to set them in the `Dockerfile`. 