### PR TITLE
Fix arg forwarding in server script

### DIFF
--- a/scripts/src/interactive.sh
+++ b/scripts/src/interactive.sh
@@ -4,6 +4,7 @@ IMAGE_NAME=""
 CONTAINER_NAME=""
 USERNAME=""
 GPUS=""
+GENERATE_HOST_NAME=true
 
 HELP_MESSAGE="
 Usage: aica-docker interactive <image> [-n <name>] [-u <user>]
@@ -24,6 +25,11 @@ Options:
 
   -u, --user <user>        Specify the name of the login user.
                            (optional)
+
+  --no-hostname            Suppress the automatic generation of a
+                           hostname for the container. By default,
+                           the container hostname is set to be
+                           the same as the container name.
 
   --gpus <gpu_options>     Add GPU access for applications that
                            require hardware acceleration (e.g. Gazebo)
@@ -47,6 +53,10 @@ while [ "$#" -gt 0 ]; do
   -n | --name)
     CONTAINER_NAME=$2
     shift 2
+    ;;
+  --no-hostname)
+    GENERATE_HOST_NAME=false
+    shift 1
     ;;
   -u | --user)
     USERNAME=$2
@@ -86,6 +96,10 @@ if [ -n "${USERNAME}" ]; then
   RUN_FLAGS+=(-u "${USERNAME}")
 fi
 
+if [ $GENERATE_HOST_NAME == true ]; then
+  RUN_FLAGS+=(--hostname "${CONTAINER_NAME}")
+fi
+
 if [ -n "${GPUS}" ]; then
   RUN_FLAGS+=(--gpus "${GPUS}")
   RUN_FLAGS+=(--env DISPLAY="${DISPLAY}")
@@ -111,6 +125,5 @@ fi
 docker run -it --rm \
   "${RUN_FLAGS[@]}" \
   --name "${CONTAINER_NAME}" \
-  --hostname "${CONTAINER_NAME}" \
   "${FWD_ARGS[@]}" \
   "${IMAGE_NAME}" /bin/bash

--- a/scripts/src/server.sh
+++ b/scripts/src/server.sh
@@ -89,11 +89,6 @@ while [ "$#" -gt 0 ]; do
     echo "${HELP_MESSAGE}"
     exit 0
     ;;
-  -*)
-    echo "Unknown option: $1" >&2
-    echo "${HELP_MESSAGE}"
-    exit 1
-    ;;
   *)
     if [ -z "${IMAGE_NAME}" ]; then
       IMAGE_NAME=$1
@@ -154,6 +149,7 @@ docker run -d --rm --cap-add sys_ptrace \
   --name "${CONTAINER_NAME}" \
   --hostname "${CONTAINER_NAME}" \
   "${RUN_FLAGS[@]}" \
+  "${FWD_ARGS[@]}" \
   "${IMAGE_NAME}" /sshd_entrypoint.sh "${COMMAND_FLAGS[@]}"
 
 echo "${CONTAINER_NAME}"

--- a/scripts/src/server.sh
+++ b/scripts/src/server.sh
@@ -57,12 +57,19 @@ the 'docker run' command.
 "
 
 CONTAINER_NAME=""
+CUSTOM_SSH_PORT=""
 
 FWD_ARGS=()
 while [ "$#" -gt 0 ]; do
   case "$1" in
   -p | --port)
-    SSH_PORT=$2
+    # only capture the port argument for SSH
+    # the first time, otherwise forward it
+    if [ -z "${CUSTOM_SSH_PORT}" ]; then
+      CUSTOM_SSH_PORT=$2
+    else
+      FWD_ARGS+=("$1 $2")
+    fi
     shift 2
     ;;
   -k | --key-file)
@@ -99,6 +106,10 @@ while [ "$#" -gt 0 ]; do
     ;;
   esac
 done
+
+if [ -n "$CUSTOM_SSH_PORT" ]; then
+  SSH_PORT="${CUSTOM_SSH_PORT}"
+fi
 
 if [ -z "$IMAGE_NAME" ]; then
   echo "No image name provided!"


### PR DESCRIPTION
I missed something in the previous PR. In the server script, it was still catching "unknown arguments" and aborting. Also, any forwarded arguments would not even have been passed to the docker run command.

Here's the simple fix.