### PR TITLE
Correct the multiple occurences replacement

### DIFF
--- a/scripts/src/interactive.sh
+++ b/scripts/src/interactive.sh
@@ -88,7 +88,7 @@ if [ -z "${IMAGE_NAME}" ]; then
 fi
 
 if [ -z "${CONTAINER_NAME}" ]; then
-  CONTAINER_NAME="${IMAGE_NAME/\//-}"
+  CONTAINER_NAME="${IMAGE_NAME//[\/.]/-}"
   CONTAINER_NAME="${CONTAINER_NAME/:/-}-runtime"
 fi
 

--- a/scripts/src/server.sh
+++ b/scripts/src/server.sh
@@ -118,7 +118,7 @@ if [ -z "$IMAGE_NAME" ]; then
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then
-  CONTAINER_NAME="${IMAGE_NAME/\//-}"
+  CONTAINER_NAME="${IMAGE_NAME//\//-}"
   CONTAINER_NAME="${CONTAINER_NAME/:/-}-ssh"
 fi
 

--- a/scripts/src/server.sh
+++ b/scripts/src/server.sh
@@ -118,7 +118,7 @@ if [ -z "$IMAGE_NAME" ]; then
 fi
 
 if [ -z "$CONTAINER_NAME" ]; then
-  CONTAINER_NAME="${IMAGE_NAME//\//-}"
+  CONTAINER_NAME="${IMAGE_NAME//[\/.]/-}"
   CONTAINER_NAME="${CONTAINER_NAME/:/-}-ssh"
 fi
 


### PR DESCRIPTION
In the server script, the container name is created by replacing the `/` in the image name by `-`. The problem is this only does it for the first occurrence. Adding an extra '/' in the command corrects this issue.