### PR TITLE
Add autocompletion option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This will create a symbolic link in `/usr/local/lib` to the scripts in this repo
 
 ```shell
 cd scripts
-sudo ./install-aica-docker.sh
+./install-aica-docker.sh
 ```
 
 To remove the `aica-docker` symbolic link and command,
@@ -49,7 +49,7 @@ simply run the [uninstall-aica-docker.sh script](scripts/install-aica-docker.sh)
 
 ```shell
 cd scripts
-sudo ./uninstall-aica-docker.sh
+./uninstall-aica-docker.sh
 ```
 
 Note: if the path of this repository is ever changed, the symbolic link will fail to find the scripts.

--- a/scripts/install-aica-docker.sh
+++ b/scripts/install-aica-docker.sh
@@ -20,7 +20,7 @@ function get_shell_rc_path () {
 }
 
 function source_completion_script () {
-  echo "Writing the auto completion option to &1."
+  echo "Writing the auto completion option to $1."
   grep -v /src/aica-docker-completion.sh "$1" > tmpfile && mv tmpfile "$1"
   if [[ "$OSTYPE" != "darwin"* ]]; then
     echo "autoload bashcompinit; bashcompinit; source ${SCRIPT_DIR}/src/aica-docker-completion.sh" >> "$1"
@@ -47,7 +47,7 @@ sudo ln -s "${SCRIPT_DIR}/aica-docker.sh" ${SYMLINK}
 SHELL_RC_PATH=$(get_shell_rc_path)
 while true; do
   read -r -p "Do you with to install auto completion for aica-docker to '${SHELL_RC_PATH}'? [yes|no]
-[yes] >>>" yn
+>>>" yn
   case $yn in
     "" | yes) source_completion_script "${SHELL_RC_PATH}"; break;;
     no) exit;;

--- a/scripts/install-aica-docker.sh
+++ b/scripts/install-aica-docker.sh
@@ -20,6 +20,7 @@ function get_shell_rc_path () {
 }
 
 function source_completion_script () {
+  echo "Writing the auto completion option to &1."
   grep -v /src/aica-docker-completion.sh "$1" > tmpfile && mv tmpfile "$1"
   if [[ "$OSTYPE" != "darwin"* ]]; then
     echo "autoload bashcompinit; bashcompinit; source ${SCRIPT_DIR}/src/aica-docker-completion.sh" >> "$1"
@@ -48,7 +49,7 @@ while true; do
   read -r -p "Do you with to install auto completion for aica-docker to '${SHELL_RC_PATH}'? [yes|no]
 [yes] >>>" yn
   case $yn in
-    yes) source_completion_script "${SHELL_RC_PATH}"; break;;
+    "" | yes) source_completion_script "${SHELL_RC_PATH}"; break;;
     no) exit;;
     *) echo "Please answer 'yes' or 'no'.";;
   esac

--- a/scripts/install-aica-docker.sh
+++ b/scripts/install-aica-docker.sh
@@ -46,7 +46,7 @@ sudo ln -s "${SCRIPT_DIR}/aica-docker.sh" ${SYMLINK}
 
 SHELL_RC_PATH=$(get_shell_rc_path)
 while true; do
-  read -r -p "Do you with to install auto completion for aica-docker to '${SHELL_RC_PATH}'? [yes|no]
+  read -r -p "Do you with to install auto completion for aica-docker to '${SHELL_RC_PATH}'? [YES|no]
 >>>" yn
   case $yn in
     "" | yes) source_completion_script "${SHELL_RC_PATH}"; break;;

--- a/scripts/install-aica-docker.sh
+++ b/scripts/install-aica-docker.sh
@@ -23,9 +23,9 @@ function source_completion_script () {
   echo "Writing the auto completion option to $1."
   grep -v /src/aica-docker-completion.sh "$1" > tmpfile && mv tmpfile "$1"
   if [[ "$OSTYPE" != "darwin"* ]]; then
-    echo "autoload bashcompinit; bashcompinit; source ${SCRIPT_DIR}/src/aica-docker-completion.sh" >> "$1"
-  else
     echo "source ${SCRIPT_DIR}/src/aica-docker-completion.sh" >> "$1"
+  else
+    echo "autoload bashcompinit; bashcompinit; source ${SCRIPT_DIR}/src/aica-docker-completion.sh" >> "$1"
   fi
 }
 

--- a/scripts/install-aica-docker.sh
+++ b/scripts/install-aica-docker.sh
@@ -1,10 +1,28 @@
 #!/bin/bash
 
+function source_completion_script () {
+  ACTUAL_USER=$(logname)
+  HOME_DIR=$(eval echo "~${ACTUAL_USER}")
+  if [[ "${SHELL##*|}" == *"zsh"* ]]; then
+    echo "source ${SCRIPT_DIR}/src/aica-docker-completion.sh" >> "${HOME_DIR}/.zshrc"
+  elif [[ "${SHELL##*|}" == *"bash"* ]]; then
+    if [[ "$OSTYPE" != "darwin"* ]]; then
+      echo "source ${SCRIPT_DIR}/src/aica-docker-completion.sh" >> "${HOME_DIR}/.bashrc"
+    else
+      echo "source ${SCRIPT_DIR}/src/aica-docker-completion.sh" >> "${HOME_DIR}/.bashrc"
+    fi
+  else
+    echo "Currently, only zsh and bash shells are supported for autocompletion with aica-docker."
+  fi
+}
+
 if [[ "$OSTYPE" != "darwin"* ]]; then
   mkdir -p /usr/local/bin
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"/aica-docker.sh
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
-echo "Creating a symbolic link from /usr/local/bin/aica-docker to ${SCRIPT_DIR}"
-ln -s "${SCRIPT_DIR}" /usr/local/bin/aica-docker
+echo "Creating a symbolic link from /usr/local/bin/aica-docker to ${SCRIPT_DIR}/aica-docker.sh"
+ln -s "${SCRIPT_DIR}/aica-docker.sh" /usr/local/bin/aica-docker
+
+source_completion_script

--- a/scripts/install-aica-docker.sh
+++ b/scripts/install-aica-docker.sh
@@ -10,7 +10,8 @@ function get_shell_rc_path () {
     if [[ "$OSTYPE" != "darwin"* ]]; then
       echo "${home_dir}/.bashrc"
     else
-      echo "${home_dir}/.bashrc"
+      echo "Currently, bash shells on Mac are not supported, please contact the maintainers."
+      exit 1
     fi
   else
     echo "Currently, only zsh and bash shells are supported for autocompletion with aica-docker."
@@ -20,7 +21,11 @@ function get_shell_rc_path () {
 
 function source_completion_script () {
   grep -v /src/aica-docker-completion.sh "$1" > tmpfile && mv tmpfile "$1"
-  echo "source ${SCRIPT_DIR}/src/aica-docker-completion.sh" >> "$1"
+  if [[ "$OSTYPE" != "darwin"* ]]; then
+    echo "autoload bashcompinit; bashcompinit; source ${SCRIPT_DIR}/src/aica-docker-completion.sh" >> "$1"
+  else
+    echo "source ${SCRIPT_DIR}/src/aica-docker-completion.sh" >> "$1"
+  fi
 }
 
 if [[ "$OSTYPE" != "darwin"* ]]; then

--- a/scripts/src/aica-docker-completion.sh
+++ b/scripts/src/aica-docker-completion.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+SCRIPTS=("connect" "interactive" "server")
+CONTAINERS=$(docker ps --format "{{ .Names }}")
+IMAGES=$(docker images --format "{{.Repository}}:{{.Tag}}")
+IMAGES=${IMAGES//"<none>:<none>"/}
+
+_aica_docker () {
+  local cur prev
+  COMPREPLY=()
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  prev="${COMP_WORDS[COMP_CWORD-1]}"
+
+  if [[ ${COMP_CWORD} -eq 2 ]]; then
+    CONTAINERS=$(docker ps --format "{{ .Names }}")
+    IMAGES=$(docker images --format "{{.Repository}}:{{.Tag}}")
+    IMAGES=${IMAGES//"<none>:<none>"/}
+  fi
+
+  case "${prev}" in
+      aica-docker)
+        COMPREPLY=($(compgen -W "${SCRIPTS[*]}" "${cur}"))
+      ;;
+      connect)
+        COMPREPLY=($(compgen -W "${CONTAINERS}" "${cur}"))
+      ;;
+      interactive|server)
+        COMPREPLY=($(compgen -W "${IMAGES}" "${cur}"))
+      ;;
+  esac
+}
+
+complete -F _aica_docker aica-docker

--- a/scripts/uninstall-aica-docker.sh
+++ b/scripts/uninstall-aica-docker.sh
@@ -10,7 +10,8 @@ function get_shell_rc_path () {
     if [[ "$OSTYPE" != "darwin"* ]]; then
       echo "${home_dir}/.bashrc"
     else
-      echo "${home_dir}/.bashrc"
+      echo "Currently, bash shells on Mac are not supported, please contact the maintainers."
+      exit 1
     fi
   else
     echo "Currently, only zsh and bash shells are supported for autocompletion with aica-docker."

--- a/scripts/uninstall-aica-docker.sh
+++ b/scripts/uninstall-aica-docker.sh
@@ -1,5 +1,21 @@
 #!/bin/bash
 
+function remove_source_completion_script () {
+  ACTUAL_USER=$(logname)
+  HOME_DIR=$(eval echo "~${ACTUAL_USER}")
+  if [[ "${SHELL##*|}" == *"zsh"* ]]; then
+    su - "${ACTUAL_USER}" -c "grep -v /src/aica-docker-completion.sh ${HOME_DIR}/.zshrc > tmpfile && mv tmpfile ${HOME_DIR}/.zshrc"
+  elif [[ "${SHELL##*|}" == *"bash"* ]]; then
+    if [[ "$OSTYPE" != "darwin"* ]]; then
+      su - "${ACTUAL_USER}" -c "grep -v /src/aica-docker-completion.sh ${HOME_DIR}/.bashrc > tmpfile && mv tmpfile ${HOME_DIR}/.bashrc"
+    else
+      su - "${ACTUAL_USER}" -c "grep -v /src/aica-docker-completion.sh ${HOME_DIR}/.bashrc > tmpfile && mv tmpfile ${HOME_DIR}/.bashrc"
+    fi
+  fi
+}
+
 SYMLINK=/usr/local/bin/aica-docker
 echo "Removing symbolic link ${SYMLINK}"
 rm -f "${SYMLINK}"
+
+remove_source_completion_script

--- a/scripts/uninstall-aica-docker.sh
+++ b/scripts/uninstall-aica-docker.sh
@@ -21,7 +21,7 @@ function get_shell_rc_path () {
 
 SYMLINK=/usr/local/bin/aica-docker
 echo "Removing symbolic link ${SYMLINK}"
-rm -f "${SYMLINK}"
+sudo rm -f "${SYMLINK}"
 
 SHELL_RC_PATH=$(get_shell_rc_path)
 if grep -Rq "/src/aica-docker-completion.sh" "${SHELL_RC_PATH}"; then

--- a/scripts/uninstall-aica-docker.sh
+++ b/scripts/uninstall-aica-docker.sh
@@ -1,16 +1,20 @@
 #!/bin/bash
 
-function remove_source_completion_script () {
-  ACTUAL_USER=$(logname)
-  HOME_DIR=$(eval echo "~${ACTUAL_USER}")
+function get_shell_rc_path () {
+  local user home_dir
+  user=$(logname)
+  home_dir=$(eval echo "~${user}")
   if [[ "${SHELL##*|}" == *"zsh"* ]]; then
-    su - "${ACTUAL_USER}" -c "grep -v /src/aica-docker-completion.sh ${HOME_DIR}/.zshrc > tmpfile && mv tmpfile ${HOME_DIR}/.zshrc"
+    echo "${home_dir}/.zshrc"
   elif [[ "${SHELL##*|}" == *"bash"* ]]; then
     if [[ "$OSTYPE" != "darwin"* ]]; then
-      su - "${ACTUAL_USER}" -c "grep -v /src/aica-docker-completion.sh ${HOME_DIR}/.bashrc > tmpfile && mv tmpfile ${HOME_DIR}/.bashrc"
+      echo "${home_dir}/.bashrc"
     else
-      su - "${ACTUAL_USER}" -c "grep -v /src/aica-docker-completion.sh ${HOME_DIR}/.bashrc > tmpfile && mv tmpfile ${HOME_DIR}/.bashrc"
+      echo "${home_dir}/.bashrc"
     fi
+  else
+    echo "Currently, only zsh and bash shells are supported for autocompletion with aica-docker."
+    exit 1
   fi
 }
 
@@ -18,4 +22,9 @@ SYMLINK=/usr/local/bin/aica-docker
 echo "Removing symbolic link ${SYMLINK}"
 rm -f "${SYMLINK}"
 
-remove_source_completion_script
+SHELL_RC_PATH=$(get_shell_rc_path)
+if grep -Rq "/src/aica-docker-completion.sh" "${SHELL_RC_PATH}"; then
+  echo "Removing auto completion from ${SHELL_RC_PATH}"
+  grep -v /src/aica-docker-completion.sh "${SHELL_RC_PATH}" > tmpfile && mv tmpfile "${SHELL_RC_PATH}"
+fi
+


### PR DESCRIPTION
There it is, the autocompletion function for our very own aica-docker hehe! 

The completion scripts need to be sourced in bashrc/zshrc so this is the only point I'm not totally sure how to do it. Maybe there should be an option for the install where the user can decide if he wants to install the auto completion or not...And then we need to make sure it works for at least bash/zsh on linux and mac...