### PR TITLE
Update workflows with repository owner variable

### DIFF
--- a/.github/actions/build-push/action.yml
+++ b/.github/actions/build-push/action.yml
@@ -4,7 +4,7 @@ inputs:
   image:
     description: 'The desired image'
     required: false
-    default: 'aica-technology/ros2-ws:foxy'
+    default: 'ros2-ws:foxy'
   cl_branch:
     description: 'The branch of control libraries'
     required: false
@@ -19,13 +19,12 @@ runs:
     - name: Build image
       run: |
         IMAGE_NAME=${{ inputs.image }}
-        IMAGE_ID=${IMAGE_NAME%:*}
         ROS_VERSION=${IMAGE_NAME#*:}
-        WORKSPACE=${IMAGE_ID#*/}
+        WORKSPACE=${IMAGE_NAME%:*}
         WORKSPACE=${WORKSPACE//[-]/_}
         mkdir -p ${WORKSPACE}/config
         cp common/sshd_entrypoint.sh ${WORKSPACE}/config/
-        docker build ${WORKSPACE} --file ${WORKSPACE}/Dockerfile  --build-arg ROS_VERSION=${ROS_VERSION} --build-arg CL_BRANCH=${{ inputs.cl_branch }} --tag ${IMAGE_ID}
+        docker build ${WORKSPACE} --file ${WORKSPACE}/Dockerfile  --build-arg ROS_VERSION=${ROS_VERSION} --build-arg CL_BRANCH=${{ inputs.cl_branch }} --tag ${IMAGE_NAME}
       shell: bash
 
     - name: Login to GitHub Container Registry
@@ -35,7 +34,6 @@ runs:
     - name: Push image
       run: |
         IMAGE_NAME=${{ inputs.image }}
-        IMAGE_ID=${IMAGE_NAME%:*}
-        docker tag ${IMAGE_ID} ghcr.io/${IMAGE_NAME}
-        docker push ghcr.io/${IMAGE_NAME}
+        docker tag ${IMAGE_NAME} ghcr.io/${{ github.repository_owner }}/${IMAGE_NAME}
+        docker push ghcr.io/${{ github.repository_owner }}/${IMAGE_NAME}
       shell: bash

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -1,6 +1,6 @@
 name: Build and Push
 
-# Run workflow on pushes to main branch or by manual dispatch
+# Run workflow on pushes to main branch
 on:
   push:
     branches:
@@ -13,26 +13,26 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and publish ROS noetic workspace image
     steps:
-      - name: Checkout Repository
+      - name: Checkout repository
         uses: actions/checkout@v2
 
       - name: Build and Push
         uses: ./.github/actions/build-push
         with:
-          image: aica-technology/ros-ws:noetic
+          image: ros-ws:noetic
           secret: ${{ secrets.GITHUB_TOKEN }}
 
   build-publish-foxy-workspace:
     runs-on: ubuntu-latest
     name: Build and publish ROS2 foxy workspace image
     steps:
-      - name: Checkout Repository
+      - name: Checkout repository
         uses: actions/checkout@v2
 
       - name: Build and Push
         uses: ./.github/actions/build-push
         with:
-          image: aica-technology/ros2-ws:foxy
+          image: ros2-ws:foxy
           secret: ${{ secrets.GITHUB_TOKEN }}
 
   build-publish-noetic-control-libraries:
@@ -40,13 +40,13 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and publish ROS noetic workspace image with control libraries installed
     steps:
-      - name: Checkout Repository
+      - name: Checkout repository
         uses: actions/checkout@v2
 
       - name: Build and Push
         uses: ./.github/actions/build-push
         with:
-          image: aica-technology/ros-control-libraries:noetic
+          image: ros-control-libraries:noetic
           cl_branch: develop
           secret: ${{ secrets.GITHUB_TOKEN }}
 
@@ -55,12 +55,12 @@ jobs:
     runs-on: ubuntu-latest
     name: Build and publish ROS2 foxy workspace image with control libraries installed
     steps:
-      - name: Checkout Repository
+      - name: Checkout repository
         uses: actions/checkout@v2
 
       - name: Build and Push
         uses: ./.github/actions/build-push
         with:
-          image: aica-technology/ros2-control-libraries:foxy
+          image: ros2-control-libraries:foxy
           cl_branch: develop
           secret: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/manual-dispatch.yml
+++ b/.github/workflows/manual-dispatch.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       image:
-        description: 'The desired image (aica-technology/<image>:<ros_distro>)'
+        description: 'The desired image (<workspace>:<ros_distro>)'
         required: true
       cl_branch:
         description: 'If set, the desired branch of control libraries for the combined image'


### PR DESCRIPTION
As I've been working on the CI a bit to check for updated repositories, I've come across some points that can be improved. As I don't want to put everything in one PR, this is the first bit of it.
Instead of hardcoding `aica-technology` to the image names everywhere, we can just use `${{ github.repository_owner }}`, a much cleaner solution.

Tested on my fork.