### PR TITLE
Robustify uninstall

### DIFF
--- a/scripts/uninstall-aica-docker.sh
+++ b/scripts/uninstall-aica-docker.sh
@@ -3,5 +3,6 @@
 SYMLINK=/usr/local/bin/aica-docker
 if test -f "$SYMLINK"; then
   echo "Removing symbolic link ${SYMLINK}"
-  rm "${SYMLINK}"
 fi
+
+rm -f "${SYMLINK}"

--- a/scripts/uninstall-aica-docker.sh
+++ b/scripts/uninstall-aica-docker.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
 SYMLINK=/usr/local/bin/aica-docker
-if test -f "$SYMLINK"; then
-  echo "Removing symbolic link ${SYMLINK}"
-fi
-
+echo "Removing symbolic link ${SYMLINK}"
 rm -f "${SYMLINK}"


### PR DESCRIPTION
* The `test -f ${FILE}` line should return true for files and
symlinks, but in case the aica-docker file in the bin is
corrupted for whatever reason it might as well use a silent
rm -f even if the check returns false

This hack should fix @buschbapti's uninstall issue (running uninstall did not remove the symlink from bin). It wait until after #15 

@domire8 