### PR TITLE
Add featherpad as text editor

### DIFF
--- a/ros2_ws/Dockerfile
+++ b/ros2_ws/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y \
   autoconf \
   automake \
   curl \
+  featherpad \
   gdb \
   git \
   iputils-ping \

--- a/ros_ws/Dockerfile
+++ b/ros_ws/Dockerfile
@@ -4,6 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \
   curl \
+  featherpad \
   gdb \
   git \
   iputils-ping \


### PR DESCRIPTION
As we sometimes have to debug within the container now (with the backend), I thought several times that a text editor with GUI would be nicer than nano because we share the display anyway. So I found this lightweight editor called `featherpad` which only adds 4MB of size to the images - compared to 500MB with `gedit`.