### PR TITLE
Remove foxy images from CI builds

### DIFF
--- a/.github/actions/build-push/action.yml
+++ b/.github/actions/build-push/action.yml
@@ -4,7 +4,7 @@ inputs:
   image:
     description: 'The desired image'
     required: false
-    default: 'ros2-ws:foxy'
+    default: 'ros2-ws:galactic'
   cl_branch:
     description: 'The branch of control libraries'
     required: false

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -9,33 +9,6 @@ on:
 
 jobs:
 
-  build-publish-noetic-workspace:
-    runs-on: ubuntu-latest
-    name: Build and publish ROS noetic workspace image
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Build and Push
-        uses: ./.github/actions/build-push
-        with:
-          image: ros-ws:noetic
-          secret: ${{ secrets.GITHUB_TOKEN }}
-
-  build-publish-foxy-workspace:
-    runs-on: ubuntu-latest
-    name: Build and publish ROS2 foxy workspace image
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Build and Push
-        uses: ./.github/actions/build-push
-        with:
-          image: ros2-ws:foxy
-          secret: ${{ secrets.GITHUB_TOKEN }}
-
-
   build-publish-galactic-workspace:
     runs-on: ubuntu-latest
     name: Build and publish ROS2 galactic workspace image
@@ -48,37 +21,6 @@ jobs:
         with:
           image: ros2-ws:galactic
           secret: ${{ secrets.GITHUB_TOKEN }}
-
-  build-publish-noetic-control-libraries:
-    needs: build-publish-noetic-workspace
-    runs-on: ubuntu-latest
-    name: Build and publish ROS noetic workspace image with control libraries installed
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Build and Push
-        uses: ./.github/actions/build-push
-        with:
-          image: ros-control-libraries:noetic
-          cl_branch: develop
-          secret: ${{ secrets.GITHUB_TOKEN }}
-
-  build-publish-foxy-control-libraries:
-    needs: build-publish-foxy-workspace
-    runs-on: ubuntu-latest
-    name: Build and publish ROS2 foxy workspace image with control libraries installed
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Build and Push
-        uses: ./.github/actions/build-push
-        with:
-          image: ros2-control-libraries:foxy
-          cl_branch: develop
-          secret: ${{ secrets.GITHUB_TOKEN }}
-
 
   build-publish-galactic-control-libraries:
     needs: build-publish-galactic-workspace
@@ -95,21 +37,6 @@ jobs:
           cl_branch: develop
           secret: ${{ secrets.GITHUB_TOKEN }}
 
-  build-publish-foxy-modulo:
-    needs: build-publish-foxy-control-libraries
-    runs-on: ubuntu-latest
-    name: Build and publish ROS2 foxy workspace image with modulo installed
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Build and Push
-        uses: ./.github/actions/build-push
-        with:
-          image: ros2-modulo:foxy
-          modulo_branch: develop
-          secret: ${{ secrets.GITHUB_TOKEN }}
-
   build-publish-galactic-modulo:
     needs: build-publish-galactic-control-libraries
     runs-on: ubuntu-latest
@@ -124,21 +51,6 @@ jobs:
           image: ros2-modulo:galactic
           modulo_branch: develop
           secret: ${{ secrets.GITHUB_TOKEN }}
-
-  build-publish-foxy-modulo-control:
-    needs: build-publish-foxy-modulo
-    runs-on: ubuntu-latest
-    name: Build and publish ROS2 foxy workspace image with modulo and ros2 control installed
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Build and Push
-        uses: ./.github/actions/build-push
-        with:
-          image: ros2-modulo-control:foxy
-          secret: ${{ secrets.GITHUB_TOKEN }}
-
 
   build-publish-galactic-modulo-control:
     needs: build-publish-galactic-modulo

--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -62,13 +62,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Build new ros2-control-libraries foxy image
-        uses: ./.github/actions/build-push
-        with:
-          image: ros2-control-libraries:foxy
-          cl_branch: develop
-          secret: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build new ros2-control-libraries galactic image
         uses: ./.github/actions/build-push
         with:
@@ -87,24 +80,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Build new ros2-modulo foxy image
-        uses: ./.github/actions/build-push
-        with:
-          image: ros2-modulo:foxy
-          modulo_branch: develop
-          secret: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Build new ros2-modulo galactic image
         uses: ./.github/actions/build-push
         with:
           image: ros2-modulo:galactic
           modulo_branch: develop
-          secret: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build new ros2-modulo-control foxy image
-        uses: ./.github/actions/build-push
-        with:
-          image: ros2-modulo-control:foxy
           secret: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build new ros2-modulo-control galactic image

--- a/ros2_control_libraries/Dockerfile
+++ b/ros2_control_libraries/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-ws
-ARG ROS_VERSION=foxy
+ARG ROS_VERSION=galactic
 FROM ${BASE_IMAGE}:${ROS_VERSION}
 
 # install google dependencies

--- a/ros2_control_libraries/build.sh
+++ b/ros2_control_libraries/build.sh
@@ -4,7 +4,7 @@ IMAGE_NAME=aica-technology/ros2-control-libraries
 
 LOCAL_BASE_IMAGE=0
 BASE_IMAGE=ghcr.io/aica-technology/ros2-ws
-ROS_VERSION=foxy
+ROS_VERSION=galactic
 CL_BRANCH=develop
 
 BUILD_FLAGS=()

--- a/ros2_modulo/Dockerfile
+++ b/ros2_modulo/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-control-libraries
-ARG ROS_VERSION=foxy
+ARG ROS_VERSION=galactic
 FROM ${BASE_IMAGE}:${ROS_VERSION}
 
 ARG MODULO_BRANCH=main

--- a/ros2_modulo/build.sh
+++ b/ros2_modulo/build.sh
@@ -4,7 +4,7 @@ IMAGE_NAME=aica-technology/ros2-modulo
 
 LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros2-control-libraries
-ROS_VERSION=foxy
+ROS_VERSION=galactic
 MODULO_BRANCH=develop
 
 BUILD_FLAGS=()

--- a/ros2_modulo_control/Dockerfile
+++ b/ros2_modulo_control/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-modulo
-ARG ROS_VERSION=foxy
+ARG ROS_VERSION=galactic
 
 FROM ${BASE_IMAGE}:foxy as ros2-control-version-foxy
 USER ${USER}
@@ -28,7 +28,7 @@ RUN git clone -b galactic --depth 1 https://github.com/ros2/test_interface_files
 RUN git clone -b ros2 --depth 1 https://github.com/ros/angles.git
 
 
-ARG ROS_VERSION=foxy
+ARG ROS_VERSION=galactic
 FROM ros2-control-version-${ROS_VERSION} AS final
 ENV ROS2_WORKSPACE /home/${USER}/ros2_ws
 WORKDIR ${ROS2_WORKSPACE}

--- a/ros2_modulo_control/build.sh
+++ b/ros2_modulo_control/build.sh
@@ -4,7 +4,7 @@ IMAGE_NAME=aica-technology/ros2-modulo-control
 
 LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros2-modulo
-ROS_VERSION=foxy
+ROS_VERSION=galactic
 
 BUILD_FLAGS=()
 while [ "$#" -gt 0 ]; do

--- a/ros2_ws/Dockerfile
+++ b/ros2_ws/Dockerfile
@@ -1,4 +1,4 @@
-ARG ROS_VERSION=foxy
+ARG ROS_VERSION=galactic
 FROM ros:${ROS_VERSION} as base-dependencies
 ENV DEBIAN_FRONTEND=noninteractive
 

--- a/ros2_ws/build.sh
+++ b/ros2_ws/build.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-ROS_VERSION=foxy
+ROS_VERSION=galactic
 docker pull "ros:${ROS_VERSION}"
 
 IMAGE_NAME=aica-technology/ros2-ws:"${ROS_VERSION}"

--- a/scripts/src/interactive.sh
+++ b/scripts/src/interactive.sh
@@ -21,8 +21,8 @@ Options:
                            the image name, replacing all
                            '/' and ':' with '-' and appending
                            '-runtime'. For example, the image
-                           aica-technology/ros2-ws:foxy would yield
-                           aica-technology-ros2-ws-foxy-runtime
+                           aica-technology/ros2-ws:galactic would yield
+                           aica-technology-ros2-ws-galactic-runtime
 
   -u, --user <user>        Specify the name of the login user.
                            (optional)

--- a/scripts/src/server.sh
+++ b/scripts/src/server.sh
@@ -40,8 +40,8 @@ Options:
                            the image name, replacing all
                            '/' and ':' with '-' and appending
                            '-ssh'. For example, the image
-                           aica-technology/ros2-ws:foxy would yield
-                           aica-technology-ros2-ws-foxy-ssh
+                           aica-technology/ros2-ws:galactic would yield
+                           aica-technology-ros2-ws-galactic-ssh
 
   -u, --user <user>        Specify the name of the remote user.
                            (default: ${USERNAME})


### PR DESCRIPTION
I did two things here, hence two commits.
- change all the default tags and args in the build scripts and Dockerfile to galactic
- remove the foxy and noetic images from the automatic CI. Note that its still possible to build those through the manual build action so the only thing we loose is the *automatic* build, we can still do it manually