### PR TITLE
Python installation from source

### DIFF
--- a/ros2_ws/Dockerfile
+++ b/ros2_ws/Dockerfile
@@ -5,23 +5,35 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
   autoconf \
   automake \
+  build-essential \
   curl \
   featherpad \
   gdb \
   git \
   iputils-ping \
   libboost-all-dev \
+  libbz2-dev \
+  libncurses5-dev \
+  libncursesw5-dev \
+  libreadline-dev \
+  libsqlite3-dev \
+  libssl-dev \
   libtool \
+  llvm \
+  make \
   mesa-utils \
   nano \
-  python3-pip \
   ros-${ROS_DISTRO}-xacro \
   ros-${ROS_DISTRO}-robot-state-publisher \
   ros-${ROS_DISTRO}-rviz2 \
   rsync \
   software-properties-common \
   ssh \
+  tk-dev \
   unzip \
+  wget \
+  xz-utils \
+  zlib1g-dev \
   && rm -rf /var/lib/apt/lists/*
 
 RUN echo "Set disable_coredump false" >> /etc/sudo.conf
@@ -35,7 +47,19 @@ RUN ( \
   && mkdir /run/sshd
 
 
-FROM base-dependencies as base-workspace
+FROM base-dependencies as python3-install
+ARG PYTHON_VER=3.10.2
+WORKDIR /tmp
+
+RUN wget https://www.python.org/ftp/python/${PYTHON_VER}/Python-${PYTHON_VER}.tar.xz
+RUN sudo tar -xf Python-${PYTHON_VER}.tar.xz
+WORKDIR Python-${PYTHON_VER}
+RUN sudo ./configure --enable-optimizations --with-ensurepip=install \
+  && sudo make -j8 \
+  && sudo make install
+
+
+FROM python3-install as base-workspace
 ENV USER ros2
 ENV HOME /home/${USER}
 ENV ROS2_WORKSPACE /home/${USER}/ros2_ws
@@ -76,4 +100,4 @@ USER ${USER}
 WORKDIR ${ROS2_WORKSPACE}
 
 # Clean image
-RUN sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
+RUN sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/* && sudo rm -rf /tmp/*


### PR DESCRIPTION
* Install a specific python version from source

This adds python installation from source, so that we can choose precisely what version of python we want as the system default. It requires a reasonable amount of time to build, and some extra build tools. Thankfully, this base image very rarely has to be rebuilt (usually once a month or so), so the extra build time is not a big problem. And, I think a lot of the build tools already existed in the base image, but it would take some effort to check each one manually, so for now we just list them all in the initial `apt-get install`. Finally, perhaps some of the build tools could be removed from the image at the end to reduce file size, but that would also be best as a separate refactor.

When it was built locally, I had `python3 --version >> 3.10.2` as expected