### PR TITLE
Reduce installation size

### DIFF
--- a/ros2_control_libraries/build.sh
+++ b/ros2_control_libraries/build.sh
@@ -2,7 +2,7 @@
 
 IMAGE_NAME=aica-technology/ros2-control-libraries
 
-LOCAL_BASE_IMAGE=0
+LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros2-ws
 ROS_VERSION=galactic
 CL_BRANCH=develop
@@ -11,7 +11,7 @@ BUILD_FLAGS=()
 while [ "$#" -gt 0 ]; do
   case "$1" in
   --local-base)
-    LOCAL_BASE_IMAGE=1
+    LOCAL_BASE_IMAGE=true
     shift 1
     ;;
   --ros-version)

--- a/ros2_ws/Dockerfile
+++ b/ros2_ws/Dockerfile
@@ -2,7 +2,8 @@ ARG ROS_VERSION=galactic
 FROM ros:${ROS_VERSION} as base-dependencies
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get install -y \
+
+RUN apt-get update && apt-get install --no-install-recommends -y \
   autoconf \
   automake \
   curl \
@@ -25,6 +26,13 @@ RUN apt-get update && apt-get install -y \
   && rm -rf /var/lib/apt/lists/*
 
 RUN echo "Set disable_coredump false" >> /etc/sudo.conf
+
+# disable suggested and recommended install
+RUN apt-config dump | grep -we Recommends -e Suggests | sed s/1/0/ \
+  | sudo tee /etc/apt/apt.conf.d/999norecommend
+
+# disable pip caching
+ENV PIP_NO_CACHE_DIR=1
 
 # Configure sshd server settings
 RUN ( \

--- a/ros_control_libraries/build.sh
+++ b/ros_control_libraries/build.sh
@@ -2,7 +2,7 @@
 
 IMAGE_NAME=aica-technology/ros-control-libraries
 
-LOCAL_BASE_IMAGE=0
+LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros-ws
 ROS_VERSION=noetic
 CL_BRANCH=develop
@@ -11,7 +11,7 @@ BUILD_FLAGS=()
 while [ "$#" -gt 0 ]; do
   case "$1" in
   --local-base)
-    LOCAL_BASE_IMAGE=1
+    LOCAL_BASE_IMAGE=true
     shift 1
     ;;
   --ros-version)
@@ -29,7 +29,7 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-if [ "${LOCAL_BASE_IMAGE}" == 1 ]; then
+if [ "${LOCAL_BASE_IMAGE}" == true ]; then
   BUILD_FLAGS+=(--build-arg BASE_IMAGE=aica-technology/ros-ws)
 else
   docker pull "${BASE_IMAGE}:${ROS_VERSION}"

--- a/ros_ws/Dockerfile
+++ b/ros_ws/Dockerfile
@@ -25,6 +25,13 @@ RUN apt-get update && apt-get install -y \
 
 RUN echo "Set disable_coredump false" >> /etc/sudo.conf
 
+# disable suggested and recommended install
+RUN apt-config dump | grep -we Recommends -e Suggests | sed s/1/0/ \
+  | sudo tee /etc/apt/apt.conf.d/999norecommend
+
+# disable pip caching
+ENV PIP_NO_CACHE_DIR=1
+
 # Configure sshd server settings
 RUN ( \
     echo 'LogLevel DEBUG2'; \


### PR DESCRIPTION
* Configure apt to not install recommended or suggested packages by 
default

* Configure pip to disable cache

This leads to a small but useful reduction in the image size of ~200MB. I tested the build pipeline locally and made sure the downstream targets (dynamic state engine) still builds and works at run time.

Also when I closed #31 to revert #28, I didn't realise it also reverted #30 - so the local base changes are re-included here.

Image sizes before and after:
- ros2-ws: 1.72 GB | 1.52 GB
- ros2-control_libraries: 2.65 GB | 2.47 GB
- ros2-modulo: 2.77 GB | 2.58 GB
- ros2-modulo-control: 3.29 GB | 3.14 GB