### PR TITLE
Install wget

### DIFF
--- a/ros2_ws/Dockerfile
+++ b/ros2_ws/Dockerfile
@@ -23,6 +23,7 @@ RUN apt-get update && apt-get install --no-install-recommends -y \
   software-properties-common \
   ssh \
   unzip \
+  wget \
   && rm -rf /var/lib/apt/lists/*
 
 RUN echo "Set disable_coredump false" >> /etc/sudo.conf


### PR DESCRIPTION
I'm using `wget` in the network interfaces library script, to download the cppzmq bindings. Would be better if we can install this here, it just increases the size of the image from 1.52 to 1.53GB