### PR TITLE
Tag development images

### DIFF
--- a/.github/actions/build-push/action.yml
+++ b/.github/actions/build-push/action.yml
@@ -1,10 +1,14 @@
 name: 'Build and Push'
 description: 'Build the Docker image and push to GitHub Container Registry'
 inputs:
-  image:
-    description: 'The desired image'
+  workspace:
+    description: 'The desired workspace'
+    required: true
+    default: 'ros2-ws'
+  ros_version:
+    description: 'The ROS distribution to use'
     required: false
-    default: 'ros2-ws:galactic'
+    default: 'galactic'
   cl_branch:
     description: 'The branch of control libraries'
     required: false
@@ -13,6 +17,14 @@ inputs:
     description: 'The branch of modulo'
     required: false
     default: 'main'
+  base_tag:
+    description: 'The tag of the base image to use (if left empty, the tag is the ROS version)'
+    required: false
+    default: ''
+  output_tag:
+    description: 'The tag for the output image (if left empty, the base tag is used)'
+    required: false
+    default: ''
   secret:
     description: 'GitHub Container Registry secret'
     required: true
@@ -20,16 +32,38 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Parse inputs
+      run: |
+        WORKSPACE_IMAGE=${{ inputs.workspace }}
+        WORKSPACE_IMAGE=${WORKSPACE_IMAGE//[_]/-}
+
+        BASE_TAG=${{ inputs.base_tag }}
+        OUTPUT_TAG=${{ inputs.output_tag }}
+        if [ -z ${BASE_TAG} ]; then
+          BASE_TAG=${{ inputs.ros_version }}
+        fi
+        echo "::debug::Using base image tag ${BASE_TAG}"
+        echo "BASE_TAG=${BASE_TAG}" >> $GITHUB_ENV
+
+        if [ -z ${OUTPUT_TAG} ]; then
+          OUTPUT_TAG=${BASE_TAG}
+        fi
+        IMAGE_NAME=${WORKSPACE_IMAGE}:${OUTPUT_TAG}
+        echo "::debug::Generated image name will be ${IMAGE_NAME}"
+        echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
+      shell: bash
+
     - name: Build image
       run: |
-        IMAGE_NAME=${{ inputs.image }}
-        ROS_VERSION=${IMAGE_NAME#*:}
-        WORKSPACE=${IMAGE_NAME%:*}
-        WORKSPACE=${WORKSPACE//[-]/_}
-        mkdir -p ${WORKSPACE}/config
-        cp common/sshd_entrypoint.sh ${WORKSPACE}/config/
-        docker build ${WORKSPACE} --file ${WORKSPACE}/Dockerfile \
-          --build-arg ROS_VERSION=${ROS_VERSION} \
+        WORKSPACE_PATH=${{ inputs.workspace}}
+        WORKSPACE_PATH=${WORKSPACE_PATH//[-]/_}
+        BASE_TAG=${{ env.BASE_TAG }}
+        IMAGE_NAME=${{ env.IMAGE_NAME }}
+
+        mkdir -p ${WORKSPACE_PATH}/config
+        cp common/sshd_entrypoint.sh ${WORKSPACE_PATH}/config/
+        docker build ${WORKSPACE_PATH} --file ${WORKSPACE_PATH}/Dockerfile \
+          --build-arg BASE_TAG=${BASE_TAG} \
           --build-arg CL_BRANCH=${{ inputs.cl_branch }} \
           --build-arg MODULO_BRANCH=${{ inputs.modulo_branch }} \
           --tag ${IMAGE_NAME}
@@ -41,7 +75,7 @@ runs:
 
     - name: Push image
       run: |
-        IMAGE_NAME=${{ inputs.image }}
+        IMAGE_NAME=${{ env.IMAGE_NAME }}
         docker tag ${IMAGE_NAME} ghcr.io/${{ github.repository_owner }}/${IMAGE_NAME}
         docker push ghcr.io/${{ github.repository_owner }}/${IMAGE_NAME}
       shell: bash

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -19,7 +19,25 @@ jobs:
       - name: Build and Push
         uses: ./.github/actions/build-push
         with:
-          image: ros2-ws:galactic
+          workspace: ros2-ws
+          ros_version: galactic
+          secret: ${{ secrets.GITHUB_TOKEN }}
+
+  build-publish-galactic-control-libraries-devel:
+    needs: build-publish-galactic-workspace
+    runs-on: ubuntu-latest
+    name: Build and publish development ROS2 galactic workspace image with control libraries installed
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build and Push
+        uses: ./.github/actions/build-push
+        with:
+          workspace: ros2-control-libraries
+          ros_version: galactic
+          cl_branch: develop
+          output_tag: galactic-devel
           secret: ${{ secrets.GITHUB_TOKEN }}
 
   build-publish-galactic-control-libraries:
@@ -33,8 +51,25 @@ jobs:
       - name: Build and Push
         uses: ./.github/actions/build-push
         with:
-          image: ros2-control-libraries:galactic
-          cl_branch: develop
+          workspace: ros2-control-libraries
+          ros_version: galactic
+          cl_branch: main
+          secret: ${{ secrets.GITHUB_TOKEN }}
+
+  build-publish-galactic-modulo-devel:
+    needs: build-publish-galactic-control-libraries-devel
+    runs-on: ubuntu-latest
+    name: Build and publish development ROS2 galactic workspace image with modulo installed
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build and Push
+        uses: ./.github/actions/build-push
+        with:
+          workspace: ros2-modulo
+          base_tag: galactic-devel
+          modulo_branch: develop
           secret: ${{ secrets.GITHUB_TOKEN }}
 
   build-publish-galactic-modulo:
@@ -48,8 +83,24 @@ jobs:
       - name: Build and Push
         uses: ./.github/actions/build-push
         with:
-          image: ros2-modulo:galactic
-          modulo_branch: develop
+          workspace: ros2-modulo
+          ros_version: galactic
+          modulo_branch: main
+          secret: ${{ secrets.GITHUB_TOKEN }}
+
+  build-publish-galactic-modulo-control-devel:
+    needs: build-publish-galactic-modulo-devel
+    runs-on: ubuntu-latest
+    name: Build and publish ROS2 galactic workspace image with modulo and ros2 control installed
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build and Push
+        uses: ./.github/actions/build-push
+        with:
+          workspace: ros2-modulo-control
+          base_tag: galactic-devel
           secret: ${{ secrets.GITHUB_TOKEN }}
 
   build-publish-galactic-modulo-control:
@@ -63,5 +114,6 @@ jobs:
       - name: Build and Push
         uses: ./.github/actions/build-push
         with:
-          image: ros2-modulo-control:galactic
+          workspace: ros2-modulo-control
+          ros_version: galactic
           secret: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -65,8 +65,10 @@ jobs:
       - name: Build new ros2-control-libraries galactic image
         uses: ./.github/actions/build-push
         with:
-          image: ros2-control-libraries:galactic
+          workspace: ros2-control-libraries
+          ros_version: galactic
           cl_branch: develop
+          output_tag: galactic-devel
           secret: ${{ secrets.GITHUB_TOKEN }}
 
   rebuild-modulo-images:
@@ -83,14 +85,16 @@ jobs:
       - name: Build new ros2-modulo galactic image
         uses: ./.github/actions/build-push
         with:
-          image: ros2-modulo:galactic
+          workspace: ros2-modulo
+          base_tag: galactic-devel
           modulo_branch: develop
           secret: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build new ros2-modulo-control galactic image
         uses: ./.github/actions/build-push
         with:
-          image: ros2-modulo-control:galactic
+          workspace: ros2-modulo-control
+          base_tag: galactic-devel
           secret: ${{ secrets.GITHUB_TOKEN }}
 
   write-hash:

--- a/.github/workflows/manual-dispatch.yml
+++ b/.github/workflows/manual-dispatch.yml
@@ -4,17 +4,29 @@ name: Manual Build and Push
 on:
   workflow_dispatch:
     inputs:
-      image:
-        description: 'The desired image (<workspace>:<ros_distro>)'
+      workspace:
+        description: 'The desired workspace (e.g. ros2-control-libraries)'
         required: true
+      ros_version:
+        description: 'The ROS distribution to use'
+        required: false
+        default: 'galactic'
       cl_branch:
-        description: 'If set, the desired branch of control libraries for the combined image'
+        description: 'The branch of control libraries'
         required: false
-        default: 'develop'
+        default: 'main'
       modulo_branch:
-        description: 'If set, the desired branch of modulo for the combined image'
+        description: 'The branch of modulo'
         required: false
-        default: 'develop'
+        default: 'main'
+      base_tag:
+        description: 'The tag of the base image to use (if left empty, the tag is the ROS version)'
+        required: false
+        default: ''
+      output_tag:
+        description: 'The tag for the output image (if left empty, the base tag is used)'
+        required: false
+        default: ''
 
 jobs:
   build-publish:
@@ -27,7 +39,10 @@ jobs:
       - name: Build and Push
         uses: ./.github/actions/build-push
         with:
-          image: ${{ github.event.inputs.image }}
+          workspace: ${{ github.event.inputs.workspace }}
+          ros_version: ${{ github.event.inputs.ros_version }}
           cl_branch: ${{ github.event.inputs.cl_branch }}
           modulo_branch: ${{ github.event.inputs.modulo_branch }}
+          base_tag: ${{ github.event.inputs.base_tag }}
+          output_tag: ${{ github.event.inputs.output_tag }}
           secret: ${{ secrets.GITHUB_TOKEN }}

--- a/ros2_control_libraries/Dockerfile
+++ b/ros2_control_libraries/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-ws
-ARG ROS_VERSION=galactic
-FROM ${BASE_IMAGE}:${ROS_VERSION}
+ARG BASE_TAG=galactic
+FROM ${BASE_IMAGE}:${BASE_TAG}
 
 # install google dependencies
 COPY --from=ghcr.io/epfl-lasa/control-libraries/proto-dependencies:latest /usr/local/include/google /usr/local/include/google

--- a/ros2_control_libraries/build.sh
+++ b/ros2_control_libraries/build.sh
@@ -4,7 +4,7 @@ IMAGE_NAME=aica-technology/ros2-control-libraries
 
 LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros2-ws
-ROS_VERSION=galactic
+BASE_TAG=galactic
 CL_BRANCH=develop
 
 BUILD_FLAGS=()
@@ -14,8 +14,8 @@ while [ "$#" -gt 0 ]; do
     LOCAL_BASE_IMAGE=true
     shift 1
     ;;
-  --ros-version)
-    ROS_VERSION=$2
+  --ros-version | --base-tag)
+    BASE_TAG=$2
     shift 2
     ;;
   --cl-branch)
@@ -32,11 +32,11 @@ done
 if [ "${LOCAL_BASE_IMAGE}" == true ]; then
   BUILD_FLAGS+=(--build-arg BASE_IMAGE=aica-technology/ros2-ws)
 else
-  docker pull "${BASE_IMAGE}:${ROS_VERSION}"
+  docker pull "${BASE_IMAGE}:${BASE_TAG}"
 fi
 
-BUILD_FLAGS+=(--build-arg ROS_VERSION="${ROS_VERSION}")
+BUILD_FLAGS+=(--build-arg BASE_TAG="${BASE_TAG}")
 BUILD_FLAGS+=(--build-arg CL_BRANCH="${CL_BRANCH}")
-BUILD_FLAGS+=(-t "${IMAGE_NAME}:${ROS_VERSION}")
+BUILD_FLAGS+=(-t "${IMAGE_NAME}:${BASE_TAG}")
 
 DOCKER_BUILDKIT=1 docker build "${BUILD_FLAGS[@]}" .

--- a/ros2_modulo/Dockerfile
+++ b/ros2_modulo/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-control-libraries
-ARG ROS_VERSION=galactic
-FROM ${BASE_IMAGE}:${ROS_VERSION}
+ARG BASE_TAG=galactic
+FROM ${BASE_IMAGE}:${BASE_TAG}
 
 ARG MODULO_BRANCH=main
 WORKDIR /tmp

--- a/ros2_modulo/build.sh
+++ b/ros2_modulo/build.sh
@@ -4,7 +4,7 @@ IMAGE_NAME=aica-technology/ros2-modulo
 
 LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros2-control-libraries
-ROS_VERSION=galactic
+BASE_TAG=galactic
 MODULO_BRANCH=develop
 
 BUILD_FLAGS=()
@@ -14,8 +14,8 @@ while [ "$#" -gt 0 ]; do
     LOCAL_BASE_IMAGE=true
     shift 1
     ;;
-  --ros-version)
-    ROS_VERSION=$2
+  --ros-version | --base-tag)
+    BASE_TAG=$2
     shift 2
     ;;
   --modulo-branch)
@@ -32,11 +32,11 @@ done
 if [ "${LOCAL_BASE_IMAGE}" = true ]; then
   BUILD_FLAGS+=(--build-arg BASE_IMAGE=aica-technology/ros2-control-libraries)
 else
-  docker pull "${BASE_IMAGE}:${ROS_VERSION}"
+  docker pull "${BASE_IMAGE}:${BASE_TAG}"
 fi
 
-BUILD_FLAGS+=(--build-arg ROS_VERSION="${ROS_VERSION}")
+BUILD_FLAGS+=(--build-arg BASE_TAG="${BASE_TAG}")
 BUILD_FLAGS+=(--build-arg MODULO_BRANCH="${MODULO_BRANCH}")
-BUILD_FLAGS+=(-t "${IMAGE_NAME}:${ROS_VERSION}")
+BUILD_FLAGS+=(-t "${IMAGE_NAME}:${BASE_TAG}")
 
 DOCKER_BUILDKIT=1 docker build "${BUILD_FLAGS[@]}" .

--- a/ros2_modulo_control/Dockerfile
+++ b/ros2_modulo_control/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-modulo
-ARG ROS_VERSION=galactic
+ARG BASE_TAG=galactic
 
 FROM ${BASE_IMAGE}:foxy as ros2-control-version-foxy
 USER ${USER}
@@ -28,8 +28,14 @@ RUN git clone -b galactic --depth 1 https://github.com/ros2/test_interface_files
 RUN git clone -b ros2 --depth 1 https://github.com/ros/angles.git
 
 
-ARG ROS_VERSION=galactic
-FROM ros2-control-version-${ROS_VERSION} AS final
+FROM ${BASE_IMAGE}:galactic-devel as ros2-control-version-galactic-devel
+USER ${USER}
+WORKDIR /home/${USER}/ros2_ws/src
+COPY --from=ros2-control-version-galactic /home/${USER}/ros2_ws/src /home/${USER}/ros2_ws/src
+
+
+ARG BASE_TAG=galactic
+FROM ros2-control-version-${BASE_TAG} AS final
 ENV ROS2_WORKSPACE /home/${USER}/ros2_ws
 WORKDIR ${ROS2_WORKSPACE}
 RUN /bin/bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash; colcon build"

--- a/ros2_modulo_control/build.sh
+++ b/ros2_modulo_control/build.sh
@@ -4,7 +4,7 @@ IMAGE_NAME=aica-technology/ros2-modulo-control
 
 LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros2-modulo
-ROS_VERSION=galactic
+BASE_TAG=galactic
 
 BUILD_FLAGS=()
 while [ "$#" -gt 0 ]; do
@@ -13,8 +13,8 @@ while [ "$#" -gt 0 ]; do
     LOCAL_BASE_IMAGE=true
     shift 1
     ;;
-  --ros-version)
-    ROS_VERSION=$2
+  --ros-version | --base-tag)
+    BASE_TAG=$2
     shift 2
     ;;
   *)
@@ -27,10 +27,10 @@ done
 if [ "${LOCAL_BASE_IMAGE}" = true ]; then
   BUILD_FLAGS+=(--build-arg BASE_IMAGE=aica-technology/ros2-modulo)
 else
-  docker pull "${BASE_IMAGE}:${ROS_VERSION}"
+  docker pull "${BASE_IMAGE}:${BASE_TAG}"
 fi
 
-BUILD_FLAGS+=(--build-arg ROS_VERSION="${ROS_VERSION}")
-BUILD_FLAGS+=(-t "${IMAGE_NAME}:${ROS_VERSION}")
+BUILD_FLAGS+=(--build-arg BASE_TAG="${BASE_TAG}")
+BUILD_FLAGS+=(-t "${IMAGE_NAME}:${BASE_TAG}")
 
 DOCKER_BUILDKIT=1 docker build "${BUILD_FLAGS[@]}" .

--- a/ros2_ws/Dockerfile
+++ b/ros2_ws/Dockerfile
@@ -1,5 +1,5 @@
-ARG ROS_VERSION=galactic
-FROM ros:${ROS_VERSION} as base-dependencies
+ARG BASE_TAG=galactic
+FROM ros:${BASE_TAG} as base-dependencies
 ENV DEBIAN_FRONTEND=noninteractive
 
 

--- a/ros2_ws/build.sh
+++ b/ros2_ws/build.sh
@@ -2,7 +2,10 @@
 ROS_VERSION=galactic
 docker pull "ros:${ROS_VERSION}"
 
-IMAGE_NAME=aica-technology/ros2-ws:"${ROS_VERSION}"
+BASE_IMAGE=aica-technology/ros2-ws
+BASE_TAG="${ROS_VERSION}"
+
+IMAGE_NAME="${BASE_IMAGE}:${BASE_TAG}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 if [[ ! -f "${SCRIPT_DIR}"/config/sshd_entrypoint.sh ]]; then
@@ -22,7 +25,7 @@ while getopts 'r' opt; do
 done
 shift "$((OPTIND - 1))"
 
-BUILD_FLAGS+=(--build-arg ROS_VERSION="${ROS_VERSION}")
+BUILD_FLAGS+=(--build-arg BASE_TAG="${BASE_TAG}")
 
 if [[ "$OSTYPE" != "darwin"* ]]; then
   USER_ID="$(id -u "${USER}")"

--- a/ros_control_libraries/Dockerfile
+++ b/ros_control_libraries/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=ghcr.io/aica-technology/ros-ws
-ARG ROS_VERSION=noetic
-FROM ${BASE_IMAGE}:${ROS_VERSION}
+ARG BASE_TAG=noetic
+FROM ${BASE_IMAGE}:${BASE_TAG}
 
 # install google dependencies
 COPY --from=ghcr.io/epfl-lasa/control-libraries/proto-dependencies:latest /usr/local/include/google /usr/local/include/google

--- a/ros_control_libraries/build.sh
+++ b/ros_control_libraries/build.sh
@@ -4,7 +4,7 @@ IMAGE_NAME=aica-technology/ros-control-libraries
 
 LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros-ws
-ROS_VERSION=noetic
+BASE_TAG=noetic
 CL_BRANCH=develop
 
 BUILD_FLAGS=()
@@ -15,7 +15,7 @@ while [ "$#" -gt 0 ]; do
     shift 1
     ;;
   --ros-version)
-    ROS_VERSION=$2
+    BASE_TAG=$2
     shift 2
     ;;
   --cl-branch)
@@ -32,11 +32,11 @@ done
 if [ "${LOCAL_BASE_IMAGE}" == true ]; then
   BUILD_FLAGS+=(--build-arg BASE_IMAGE=aica-technology/ros-ws)
 else
-  docker pull "${BASE_IMAGE}:${ROS_VERSION}"
+  docker pull "${BASE_IMAGE}:${BASE_TAG}"
 fi
 
-BUILD_FLAGS+=(--build-arg ROS_VERSION="${ROS_VERSION}")
+BUILD_FLAGS+=(--build-arg BASE_TAG="${BASE_TAG}")
 BUILD_FLAGS+=(--build-arg CL_BRANCH="${CL_BRANCH}")
-BUILD_FLAGS+=(-t "${IMAGE_NAME}:${ROS_VERSION}")
+BUILD_FLAGS+=(-t "${IMAGE_NAME}:${BASE_TAG}")
 
 DOCKER_BUILDKIT=1 docker build "${BUILD_FLAGS[@]}" .

--- a/ros_ws/Dockerfile
+++ b/ros_ws/Dockerfile
@@ -1,5 +1,5 @@
-ARG ROS_VERSION=noetic
-FROM ros:${ROS_VERSION} as base-dependencies
+ARG BASE_TAG=noetic
+FROM ros:${BASE_TAG} as base-dependencies
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \

--- a/ros_ws/build.sh
+++ b/ros_ws/build.sh
@@ -2,7 +2,10 @@
 ROS_VERSION=noetic
 docker pull "ros:${ROS_VERSION}"
 
-IMAGE_NAME=aica-technology/ros-ws:"${ROS_VERSION}"
+BASE_IMAGE=aica-technology/ros-ws
+BASE_TAG="${ROS_VERSION}"
+
+IMAGE_NAME="${BASE_IMAGE}:${BASE_TAG}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 if [[ ! -f "${SCRIPT_DIR}"/config/sshd_entrypoint.sh ]]; then
@@ -22,7 +25,7 @@ while getopts 'r' opt; do
 done
 shift "$((OPTIND - 1))"
 
-BUILD_FLAGS+=(--build-arg ROS_VERSION="${ROS_VERSION}")
+BUILD_FLAGS+=(--build-arg BASE_TAG="${BASE_TAG}")
 
 if [[ "$OSTYPE" != "darwin"* ]]; then
   USER_ID="$(id -u "${USER}")"


### PR DESCRIPTION
I want us to have a stable "main" release of our docker images alongside "development" images (which use development branches of control libraries and modulo). For this reason I propose to add more tagging logic to our build process, and by default generate a `:galactic` and `:galactic-devel` tag of our composite images.

For now `-devel` only signifies the branches of control libraries and modulo, but as you can see from the ros2-modulo-control docker file, the `devel` stage would also let us safely try newer version of ros2 control without breaking our main image.

It's more images, so more compute and hosting - but the full set of images (main and development) are only rebuilt on push to main or manual dispatch, while the check-upstream will handle the `-devel` side. We just have to manually dispatch when there is a new main release.

I forked this and tested it successfully here (with minor modifications so the base images pull from `eeberhard` instead of `aica-technology`):
https://github.com/eeberhard/docker-images-test/actions/runs/1864987461

As you can see, the packages are generated with the `galactic` and `galactic-devel` tags for [control libraries](https://github.com/eeberhard/docker-images-test/pkgs/container/docker-images-test%2Fros2-control-libraries), [modulo](https://github.com/eeberhard/docker-images-test/pkgs/container/docker-images-test%2Fros2-modulo) and [modulo-control](https://github.com/eeberhard/docker-images-test/pkgs/container/docker-images-test%2Fros2-modulo-control).

--- 

* Refactor Dockerfiles and build scripts to use BASE_TAG notation instead of ROS_VERSION for build args, to allow more diverse range of base tags when pulling from images

* Refactor build push-action inputs to increase configurability, supplying workspace and tags separately instead of compositely. Add inputs for ros version and base and output tags

* Add step to build-push action to parse workspace, tags and image name into environment variables for later steps

* Update ros2-modulo-control dockerfile to support a galactic-devel build stage

* Add development stages to build-push workflow to use development branches of control libraries and modulo, tagging them with the respecitve galactic-devel tags. Change default galactic tag images to use main branches of control libraries and modulo

* Update check-upstream and manual-dispatch workflows with new action input syntax