### PR TITLE
Remove foxy and extend build scripts

### DIFF
--- a/ros2_control_libraries/build.sh
+++ b/ros2_control_libraries/build.sh
@@ -5,7 +5,7 @@ IMAGE_NAME=aica-technology/ros2-control-libraries
 LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros2-ws
 BASE_TAG=galactic
-EXPORT_TAG=galactic
+OUTPUT_TAG=galactic
 CL_BRANCH=develop
 
 BUILD_FLAGS=()
@@ -23,8 +23,8 @@ while [ "$#" -gt 0 ]; do
     CL_BRANCH=$2
     shift 2
     ;;
-  --export-tag)
-    EXPORT_TAG=$2
+  --output-tag)
+    OUTPUT_TAG=$2
     shift 2
     ;;
   -r | --rebuild)
@@ -50,6 +50,6 @@ fi
 
 BUILD_FLAGS+=(--build-arg BASE_TAG="${BASE_TAG}")
 BUILD_FLAGS+=(--build-arg CL_BRANCH="${CL_BRANCH}")
-BUILD_FLAGS+=(-t "${IMAGE_NAME}:${EXPORT_TAG}")
+BUILD_FLAGS+=(-t "${IMAGE_NAME}:${OUTPUT_TAG}")
 
 DOCKER_BUILDKIT=1 docker build "${BUILD_FLAGS[@]}" .

--- a/ros2_control_libraries/build.sh
+++ b/ros2_control_libraries/build.sh
@@ -5,6 +5,7 @@ IMAGE_NAME=aica-technology/ros2-control-libraries
 LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros2-ws
 BASE_TAG=galactic
+EXPORT_TAG=galactic
 CL_BRANCH=develop
 
 BUILD_FLAGS=()
@@ -14,7 +15,7 @@ while [ "$#" -gt 0 ]; do
     LOCAL_BASE_IMAGE=true
     shift 1
     ;;
-  --ros-version | --base-tag)
+  --base-tag)
     BASE_TAG=$2
     shift 2
     ;;
@@ -22,8 +23,20 @@ while [ "$#" -gt 0 ]; do
     CL_BRANCH=$2
     shift 2
     ;;
+  --export-tag)
+    EXPORT_TAG=$2
+    shift 2
+    ;;
+  -r | --rebuild)
+    BUILD_FLAGS+=(--no-cache)
+    shift 1
+    ;;
+  -v | --verbose)
+    BUILD_FLAGS+=(--progress=plain)
+    shift 1
+    ;;
   *)
-    echo 'Error in command line parsing' >&2
+    echo "Unknown option: $1" >&2
     exit 1
     ;;
   esac
@@ -37,6 +50,6 @@ fi
 
 BUILD_FLAGS+=(--build-arg BASE_TAG="${BASE_TAG}")
 BUILD_FLAGS+=(--build-arg CL_BRANCH="${CL_BRANCH}")
-BUILD_FLAGS+=(-t "${IMAGE_NAME}:${BASE_TAG}")
+BUILD_FLAGS+=(-t "${IMAGE_NAME}:${EXPORT_TAG}")
 
 DOCKER_BUILDKIT=1 docker build "${BUILD_FLAGS[@]}" .

--- a/ros2_modulo/build.sh
+++ b/ros2_modulo/build.sh
@@ -5,7 +5,7 @@ IMAGE_NAME=aica-technology/ros2-modulo
 LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros2-control-libraries
 BASE_TAG=galactic
-EXPORT_TAG=galactic
+OUTPUT_TAG=galactic
 MODULO_BRANCH=develop
 
 BUILD_FLAGS=()
@@ -23,8 +23,8 @@ while [ "$#" -gt 0 ]; do
     MODULO_BRANCH=$2
     shift 2
     ;;
-  --export-tag)
-    EXPORT_TAG=$2
+  --output-tag)
+    OUTPUT_TAG=$2
     shift 2
     ;;
   -r | --rebuild)
@@ -50,6 +50,6 @@ fi
 
 BUILD_FLAGS+=(--build-arg BASE_TAG="${BASE_TAG}")
 BUILD_FLAGS+=(--build-arg MODULO_BRANCH="${MODULO_BRANCH}")
-BUILD_FLAGS+=(-t "${IMAGE_NAME}:${EXPORT_TAG}")
+BUILD_FLAGS+=(-t "${IMAGE_NAME}:${OUTPUT_TAG}")
 
 DOCKER_BUILDKIT=1 docker build "${BUILD_FLAGS[@]}" .

--- a/ros2_modulo/build.sh
+++ b/ros2_modulo/build.sh
@@ -5,6 +5,7 @@ IMAGE_NAME=aica-technology/ros2-modulo
 LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros2-control-libraries
 BASE_TAG=galactic
+EXPORT_TAG=galactic
 MODULO_BRANCH=develop
 
 BUILD_FLAGS=()
@@ -14,7 +15,7 @@ while [ "$#" -gt 0 ]; do
     LOCAL_BASE_IMAGE=true
     shift 1
     ;;
-  --ros-version | --base-tag)
+  --base-tag)
     BASE_TAG=$2
     shift 2
     ;;
@@ -22,8 +23,20 @@ while [ "$#" -gt 0 ]; do
     MODULO_BRANCH=$2
     shift 2
     ;;
+  --export-tag)
+    EXPORT_TAG=$2
+    shift 2
+    ;;
+  -r | --rebuild)
+    BUILD_FLAGS+=(--no-cache)
+    shift 1
+    ;;
+  -v | --verbose)
+    BUILD_FLAGS+=(--progress=plain)
+    shift 1
+    ;;
   *)
-    echo 'Error in command line parsing' >&2
+    echo "Unknown option: $1" >&2
     exit 1
     ;;
   esac
@@ -37,6 +50,6 @@ fi
 
 BUILD_FLAGS+=(--build-arg BASE_TAG="${BASE_TAG}")
 BUILD_FLAGS+=(--build-arg MODULO_BRANCH="${MODULO_BRANCH}")
-BUILD_FLAGS+=(-t "${IMAGE_NAME}:${BASE_TAG}")
+BUILD_FLAGS+=(-t "${IMAGE_NAME}:${EXPORT_TAG}")
 
 DOCKER_BUILDKIT=1 docker build "${BUILD_FLAGS[@]}" .

--- a/ros2_modulo_control/Dockerfile
+++ b/ros2_modulo_control/Dockerfile
@@ -1,17 +1,7 @@
 ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-modulo
 ARG BASE_TAG=galactic
 
-FROM ${BASE_IMAGE}:foxy as ros2-control-version-foxy
-USER ${USER}
-
-RUN sudo apt-get update && sudo apt-get install -y \
-  ros-${ROS_DISTRO}-ros2-control \
-  ros-${ROS_DISTRO}-ros2-controllers \
-  && sudo ldconfig \
-  && sudo rm -rf /var/lib/apt/lists/*
-
-
-FROM ${BASE_IMAGE}:galactic as ros2-control-version-galactic
+FROM ${BASE_IMAGE}:${BASE_TAG}
 USER ${USER}
 ARG ROS2_CONTROL_TAG=1.0.0
 
@@ -27,15 +17,6 @@ RUN git clone -b galactic --depth 1 https://github.com/ros2/rcl_interfaces.git
 RUN git clone -b galactic --depth 1 https://github.com/ros2/test_interface_files.git
 RUN git clone -b ros2 --depth 1 https://github.com/ros/angles.git
 
-
-FROM ${BASE_IMAGE}:galactic-devel as ros2-control-version-galactic-devel
-USER ${USER}
-WORKDIR /home/${USER}/ros2_ws/src
-COPY --from=ros2-control-version-galactic /home/${USER}/ros2_ws/src /home/${USER}/ros2_ws/src
-
-
-ARG BASE_TAG=galactic
-FROM ros2-control-version-${BASE_TAG} AS final
 ENV ROS2_WORKSPACE /home/${USER}/ros2_ws
 WORKDIR ${ROS2_WORKSPACE}
 RUN /bin/bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash; colcon build"

--- a/ros2_modulo_control/build.sh
+++ b/ros2_modulo_control/build.sh
@@ -4,7 +4,8 @@ IMAGE_NAME=aica-technology/ros2-modulo-control
 
 LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros2-modulo
-BASE_TAG=galactic
+BASE_TAG=galactic-test
+EXPORT_TAG=galactic
 
 BUILD_FLAGS=()
 while [ "$#" -gt 0 ]; do
@@ -13,12 +14,24 @@ while [ "$#" -gt 0 ]; do
     LOCAL_BASE_IMAGE=true
     shift 1
     ;;
-  --ros-version | --base-tag)
+  --base-tag)
     BASE_TAG=$2
     shift 2
     ;;
+  --export-tag)
+    EXPORT_TAG=$2
+    shift 2
+    ;;
+  -r | --rebuild)
+    BUILD_FLAGS+=(--no-cache)
+    shift 1
+    ;;
+  -v | --verbose)
+    BUILD_FLAGS+=(--progress=plain)
+    shift 1
+    ;;
   *)
-    echo 'Error in command line parsing' >&2
+    echo "Unknown option: $1" >&2
     exit 1
     ;;
   esac
@@ -31,6 +44,6 @@ else
 fi
 
 BUILD_FLAGS+=(--build-arg BASE_TAG="${BASE_TAG}")
-BUILD_FLAGS+=(-t "${IMAGE_NAME}:${BASE_TAG}")
+BUILD_FLAGS+=(-t "${IMAGE_NAME}:${EXPORT_TAG}")
 
 DOCKER_BUILDKIT=1 docker build "${BUILD_FLAGS[@]}" .

--- a/ros2_modulo_control/build.sh
+++ b/ros2_modulo_control/build.sh
@@ -5,7 +5,7 @@ IMAGE_NAME=aica-technology/ros2-modulo-control
 LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros2-modulo
 BASE_TAG=galactic-test
-EXPORT_TAG=galactic
+OUTPUT_TAG=galactic
 
 BUILD_FLAGS=()
 while [ "$#" -gt 0 ]; do
@@ -18,8 +18,8 @@ while [ "$#" -gt 0 ]; do
     BASE_TAG=$2
     shift 2
     ;;
-  --export-tag)
-    EXPORT_TAG=$2
+  --output-tag)
+    OUTPUT_TAG=$2
     shift 2
     ;;
   -r | --rebuild)
@@ -44,6 +44,6 @@ else
 fi
 
 BUILD_FLAGS+=(--build-arg BASE_TAG="${BASE_TAG}")
-BUILD_FLAGS+=(-t "${IMAGE_NAME}:${EXPORT_TAG}")
+BUILD_FLAGS+=(-t "${IMAGE_NAME}:${OUTPUT_TAG}")
 
 DOCKER_BUILDKIT=1 docker build "${BUILD_FLAGS[@]}" .

--- a/ros2_modulo_control/build.sh
+++ b/ros2_modulo_control/build.sh
@@ -4,7 +4,7 @@ IMAGE_NAME=aica-technology/ros2-modulo-control
 
 LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros2-modulo
-BASE_TAG=galactic-test
+BASE_TAG=galactic
 OUTPUT_TAG=galactic
 
 BUILD_FLAGS=()

--- a/ros2_ws/Dockerfile
+++ b/ros2_ws/Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_TAG=galactic
-FROM ros:${BASE_TAG} as base-dependencies
+ARG ROS_VERSION=galactic
+FROM ros:${ROS_VERSION} as base-dependencies
 ENV DEBIAN_FRONTEND=noninteractive
 
 

--- a/ros2_ws/build.sh
+++ b/ros2_ws/build.sh
@@ -1,11 +1,7 @@
 #!/bin/bash
+
+IMAGE_NAME=aica-technology/ros2-ws
 ROS_VERSION=galactic
-docker pull "ros:${ROS_VERSION}"
-
-BASE_IMAGE=aica-technology/ros2-ws
-BASE_TAG="${ROS_VERSION}"
-
-IMAGE_NAME="${BASE_IMAGE}:${BASE_TAG}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 if [[ ! -f "${SCRIPT_DIR}"/config/sshd_entrypoint.sh ]]; then
@@ -14,18 +10,29 @@ if [[ ! -f "${SCRIPT_DIR}"/config/sshd_entrypoint.sh ]]; then
 fi
 
 BUILD_FLAGS=()
-while getopts 'r' opt; do
-  case $opt in
-  r) BUILD_FLAGS+=(--no-cache) ;;
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+  --ros-version)
+    ROS_VERSION=$2
+    shift 2
+    ;;
+  -r | --rebuild)
+    BUILD_FLAGS+=(--no-cache)
+    shift 1
+    ;;
+  -v | --verbose)
+    BUILD_FLAGS+=(--progress=plain)
+    shift 1
+    ;;
   *)
-    echo 'Error in command line parsing' >&2
+    echo "Unknown option: $1" >&2
     exit 1
     ;;
   esac
 done
-shift "$((OPTIND - 1))"
 
-BUILD_FLAGS+=(--build-arg BASE_TAG="${BASE_TAG}")
+docker pull "ros:${ROS_VERSION}"
+BUILD_FLAGS+=(--build-arg ROS_VERSION="${ROS_VERSION}")
 
 if [[ "$OSTYPE" != "darwin"* ]]; then
   USER_ID="$(id -u "${USER}")"
@@ -34,6 +41,6 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
   BUILD_FLAGS+=(--build-arg GID="${GROUP_ID}")
 fi
 
-BUILD_FLAGS+=(-t "${IMAGE_NAME}")
+BUILD_FLAGS+=(-t "${IMAGE_NAME}":"${ROS_VERSION}")
 
 DOCKER_BUILDKIT=1 docker build "${BUILD_FLAGS[@]}" .

--- a/ros_control_libraries/build.sh
+++ b/ros_control_libraries/build.sh
@@ -5,6 +5,7 @@ IMAGE_NAME=aica-technology/ros-control-libraries
 LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros-ws
 BASE_TAG=noetic
+EXPORT_TAG=noetic
 CL_BRANCH=develop
 
 BUILD_FLAGS=()
@@ -14,13 +15,25 @@ while [ "$#" -gt 0 ]; do
     LOCAL_BASE_IMAGE=true
     shift 1
     ;;
-  --ros-version)
+  --base-tag)
     BASE_TAG=$2
     shift 2
     ;;
   --cl-branch)
     CL_BRANCH=$2
     shift 2
+    ;;
+  --export-tag)
+    EXPORT_TAG=$2
+    shift 2
+    ;;
+  -r | --rebuild)
+    BUILD_FLAGS+=(--no-cache)
+    shift 1
+    ;;
+  -v | --verbose)
+    BUILD_FLAGS+=(--progress=plain)
+    shift 1
     ;;
   *)
     echo "Unknown option: $1" >&2
@@ -37,6 +50,6 @@ fi
 
 BUILD_FLAGS+=(--build-arg BASE_TAG="${BASE_TAG}")
 BUILD_FLAGS+=(--build-arg CL_BRANCH="${CL_BRANCH}")
-BUILD_FLAGS+=(-t "${IMAGE_NAME}:${BASE_TAG}")
+BUILD_FLAGS+=(-t "${IMAGE_NAME}:${EXPORT_TAG}")
 
 DOCKER_BUILDKIT=1 docker build "${BUILD_FLAGS[@]}" .

--- a/ros_control_libraries/build.sh
+++ b/ros_control_libraries/build.sh
@@ -5,7 +5,7 @@ IMAGE_NAME=aica-technology/ros-control-libraries
 LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros-ws
 BASE_TAG=noetic
-EXPORT_TAG=noetic
+OUTPUT_TAG=noetic
 CL_BRANCH=develop
 
 BUILD_FLAGS=()
@@ -23,8 +23,8 @@ while [ "$#" -gt 0 ]; do
     CL_BRANCH=$2
     shift 2
     ;;
-  --export-tag)
-    EXPORT_TAG=$2
+  --output-tag)
+    OUTPUT_TAG=$2
     shift 2
     ;;
   -r | --rebuild)
@@ -50,6 +50,6 @@ fi
 
 BUILD_FLAGS+=(--build-arg BASE_TAG="${BASE_TAG}")
 BUILD_FLAGS+=(--build-arg CL_BRANCH="${CL_BRANCH}")
-BUILD_FLAGS+=(-t "${IMAGE_NAME}:${EXPORT_TAG}")
+BUILD_FLAGS+=(-t "${IMAGE_NAME}:${OUTPUT_TAG}")
 
 DOCKER_BUILDKIT=1 docker build "${BUILD_FLAGS[@]}" .

--- a/ros_ws/Dockerfile
+++ b/ros_ws/Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_TAG=noetic
-FROM ros:${BASE_TAG} as base-dependencies
+ARG ROS_VERSION=noetic
+FROM ros:${ROS_VERSION} as base-dependencies
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
So @eeberhard and me decided to remove foxy from the `ros2-modulo-control` image because 
- this Dockerfile is kind of annyoing with the different stages and we will not switch back to foxy anyway
- the new improved manual dispatch does not work with other tags than foxy, galactic and galactic-devel, which is kind of sad as well

Therefore, I decided to adapt the build scripts and their arguments according to the new workflow dispatch options - i.e. that you can provide a base tag and an output tag (except for the workspace image where the base tag as well as the output tag are the ROS version). I also took the chance to add verbose and rebuild options to the build scripts