### PR TITLE
Write sha256 hashes of images to file

### DIFF
--- a/.github/actions/build-push/action.yml
+++ b/.github/actions/build-push/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: 'Write image SHA256 hash to file'
     required: false
     default: 'true'
+  ci_branch:
+    description: 'The name of the CI branch'
+    required: false
+    default: 'ci'
   secret:
     description: 'GitHub Container Registry secret'
     required: true

--- a/.github/actions/build-push/action.yml
+++ b/.github/actions/build-push/action.yml
@@ -91,7 +91,7 @@ runs:
       run: |
         git config user.name github-actions
         git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-        git fetch && git checkout ci && git pull && git rebase origin/main
+        git fetch origin ${{ inputs.ci_branch }} && git checkout ${{ inputs.ci_branch }} && git rebase origin/main
         SHA=$(docker images --no-trunc --quiet ${IMAGE_NAME})
         echo ${SHA} > ./${{ env.WORKSPACE_PATH }}/${{ env.OUTPUT_TAG }}-hash
         git add ./${{ env.WORKSPACE_PATH }}/${{ env.OUTPUT_TAG }}-hash

--- a/.github/actions/build-push/action.yml
+++ b/.github/actions/build-push/action.yml
@@ -25,6 +25,10 @@ inputs:
     description: 'The tag for the output image (if left empty, the base tag is used)'
     required: false
     default: ''
+  write_image_hash:
+    description: 'Write image SHA256 hash to file'
+    required: false
+    default: 'true'
   secret:
     description: 'GitHub Container Registry secret'
     required: true
@@ -48,6 +52,7 @@ runs:
         if [ -z ${OUTPUT_TAG} ]; then
           OUTPUT_TAG=${BASE_TAG}
         fi
+        echo "OUTPUT_TAG=${OUTPUT_TAG}" >> $GITHUB_ENV
         IMAGE_NAME=${WORKSPACE_IMAGE}:${OUTPUT_TAG}
         echo "::debug::Generated image name will be ${IMAGE_NAME}"
         echo "IMAGE_NAME=${IMAGE_NAME}" >> $GITHUB_ENV
@@ -55,8 +60,9 @@ runs:
 
     - name: Build image
       run: |
-        WORKSPACE_PATH=${{ inputs.workspace}}
+        WORKSPACE_PATH=${{ inputs.workspace }}
         WORKSPACE_PATH=${WORKSPACE_PATH//[-]/_}
+        echo "WORKSPACE_PATH=${WORKSPACE_PATH}" >> $GITHUB_ENV
         BASE_TAG=${{ env.BASE_TAG }}
         IMAGE_NAME=${{ env.IMAGE_NAME }}
 
@@ -78,4 +84,16 @@ runs:
         IMAGE_NAME=${{ env.IMAGE_NAME }}
         docker tag ${IMAGE_NAME} ghcr.io/${{ github.repository_owner }}/${IMAGE_NAME}
         docker push ghcr.io/${{ github.repository_owner }}/${IMAGE_NAME}
+      shell: bash
+
+    - name: Write new image hash to file
+      if: ${{ inputs.write_image_hash == 'true' }}
+      run: |
+        git config user.name github-actions
+        git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+        git fetch && git checkout ci && git pull && git rebase origin/main
+        SHA=$(docker images --no-trunc --quiet ${IMAGE_NAME})
+        echo ${SHA} > ./${{ env.WORKSPACE_PATH }}/${{ env.OUTPUT_TAG }}-hash
+        git add ./${{ env.WORKSPACE_PATH }}/${{ env.OUTPUT_TAG }}-hash
+        git commit -m "Update ${{ env.IMAGE_NAME }} image hash" && git push -f
       shell: bash

--- a/.github/actions/write-hash/action.yml
+++ b/.github/actions/write-hash/action.yml
@@ -21,7 +21,7 @@ runs:
       run: |
         git config user.name github-actions
         git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-        git fetch origin ${{ inputs.ci_branch }}:${{ inputs.ci_branch }} && git checkout ${{ inputs.ci_branch }} && git rebase origin/main
+        git fetch origin ${{ inputs.ci_branch }} && git checkout ${{ inputs.ci_branch }} && git rebase origin/main
         echo ${{ inputs.hash }} > ${{ inputs.file }}
         git add ${{ inputs.file }}
         git commit -m "Update hash in ${{ inputs.file }}" && git push -f

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           workspace: ros2-ws
           ros_version: galactic
+          ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
 
   build-publish-galactic-control-libraries-devel:
@@ -55,6 +56,7 @@ jobs:
           ros_version: galactic
           cl_branch: develop
           output_tag: galactic-devel
+          ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get control libraries hash
@@ -83,6 +85,7 @@ jobs:
           workspace: ros2-control-libraries
           ros_version: galactic
           cl_branch: main
+          ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
 
   build-publish-galactic-modulo-devel:
@@ -99,6 +102,7 @@ jobs:
           workspace: ros2-modulo
           base_tag: galactic-devel
           modulo_branch: develop
+          ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get modulo hash
@@ -127,6 +131,7 @@ jobs:
           workspace: ros2-modulo
           ros_version: galactic
           modulo_branch: main
+          ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
 
   build-publish-galactic-modulo-control-devel:
@@ -142,6 +147,7 @@ jobs:
         with:
           workspace: ros2-modulo-control
           base_tag: galactic-devel
+          ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
 
   build-publish-galactic-modulo-control:
@@ -157,4 +163,5 @@ jobs:
         with:
           workspace: ros2-modulo-control
           ros_version: galactic
+          ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -70,6 +70,7 @@ jobs:
           ros_version: galactic
           cl_branch: develop
           output_tag: galactic-devel
+          ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Write hash to file and push to ci branch
@@ -95,6 +96,7 @@ jobs:
           workspace: ros2-modulo
           base_tag: galactic-devel
           modulo_branch: develop
+          ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Write hash to file and push to ci branch
@@ -119,4 +121,5 @@ jobs:
         with:
           workspace: ros2-modulo-control
           base_tag: galactic-devel
+          ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/manual-dispatch.yml
+++ b/.github/workflows/manual-dispatch.yml
@@ -27,6 +27,10 @@ on:
         description: 'The tag for the output image (if left empty, the base tag is used)'
         required: false
         default: ''
+      write_image_hash:
+        description: 'Write image SHA256 hash to file (set to false for temporary or test images)'
+        required: false
+        default: 'true'
 
 jobs:
   build-publish:
@@ -45,4 +49,5 @@ jobs:
           modulo_branch: ${{ github.event.inputs.modulo_branch }}
           base_tag: ${{ github.event.inputs.base_tag }}
           output_tag: ${{ github.event.inputs.output_tag }}
+          write_image_hash: ${{ github.event.inputs.write_image_hash }}
           secret: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/manual-dispatch.yml
+++ b/.github/workflows/manual-dispatch.yml
@@ -32,6 +32,9 @@ on:
         required: false
         default: 'true'
 
+env:
+  CI_BRANCH: 'ci'
+
 jobs:
   build-publish:
     runs-on: ubuntu-latest
@@ -50,4 +53,5 @@ jobs:
           base_tag: ${{ github.event.inputs.base_tag }}
           output_tag: ${{ github.event.inputs.output_tag }}
           write_image_hash: ${{ github.event.inputs.write_image_hash }}
+          ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}

--- a/ros2_modulo/Dockerfile
+++ b/ros2_modulo/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /tmp
 RUN git clone -b ${MODULO_BRANCH} --depth 1 https://github.com/epfl-lasa/modulo.git
 
 # copy sources and build ROS workspace with user permissions
-RUN cp -r /tmp/modulo/source/ ${ROS2_WORKSPACE}/src
+RUN cp -r /tmp/modulo/source/modulo_core ${ROS2_WORKSPACE}/src/
 
 WORKDIR ${ROS2_WORKSPACE}
 RUN /bin/bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash; colcon build"

--- a/ros2_modulo/Dockerfile
+++ b/ros2_modulo/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /tmp
 RUN git clone -b ${MODULO_BRANCH} --depth 1 https://github.com/epfl-lasa/modulo.git
 
 # copy sources and build ROS workspace with user permissions
-RUN cp -r /tmp/modulo/source/modulo_core ${ROS2_WORKSPACE}/src/
+RUN cp -r /tmp/modulo/source/ ${ROS2_WORKSPACE}/src
 
 WORKDIR ${ROS2_WORKSPACE}
 RUN /bin/bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash; colcon build"


### PR DESCRIPTION
With these changes, the CI writes the sha256 hashes of generated images to a file in the workspace folder. For example, after building `ros2-modulo:galactic-devel` there will be a file on the `ci` branch under `ros2_modulo/galactic-devel-hash` containing the sha256 hash of the pushed image. This allows downstream repos to check for updated images.

For the manual workflow dispatch, where we can generate any kind of tags, there is the option to disable writing the hash to file.

See https://github.com/domire8/docker-images/tree/ci