### PR TITLE
Improve CI

### DIFF
--- a/.github/actions/write-hash/action.yml
+++ b/.github/actions/write-hash/action.yml
@@ -21,7 +21,7 @@ runs:
       run: |
         git config user.name github-actions
         git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-        git fetch && git checkout ${{ inputs.ci_branch }} && git pull && git rebase origin/main
+        git fetch origin ${{ inputs.ci_branch }}:${{ inputs.ci_branch }} && git checkout ${{ inputs.ci_branch }} && git rebase origin/main
         echo ${{ inputs.hash }} > ${{ inputs.file }}
         git add ${{ inputs.file }}
         git commit -m "Update hash in ${{ inputs.file }}" && git push -f

--- a/.github/actions/write-hash/action.yml
+++ b/.github/actions/write-hash/action.yml
@@ -1,0 +1,28 @@
+name: 'Write hash to file'
+description: 'Write a hash to a file and push it to the CI branch'
+inputs:
+  hash:
+    description: 'The hash to be written to file'
+    required: true
+    default: ''
+  file:
+    description: 'The filename (relative path from top level directory)'
+    required: true
+    default: ''
+  ci_branch:
+    description: 'The name of the CI branch'
+    required: false
+    default: 'ci'
+
+runs:
+  using: "composite"
+  steps:
+    - name: Write hash to file
+      run: |
+        git config user.name github-actions
+        git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+        git fetch && git checkout ${{ inputs.ci_branch }} && git pull && git rebase origin/main
+        echo ${{ inputs.hash }} > ${{ inputs.file }}
+        git add ${{ inputs.file }}
+        git commit -m "Update hash in ${{ inputs.file }}" && git push -f
+      shell: bash

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           git config user.name github-actions
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git checkout -b ${{ env.CI_BRANCH }} && git push -f -u origin ${{ env.CI_BRANCH }}
+          git checkout -b ${{ env.CI_BRANCH }} origin/main && git push -f -u origin ${{ env.CI_BRANCH }}
 
   build-publish-galactic-workspace:
     needs: create-new-ci-branch

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -57,6 +57,18 @@ jobs:
           output_tag: galactic-devel
           secret: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Get control libraries hash
+        run: |
+          HASH=$(git ls-remote https://github.com/epfl-lasa/control-libraries.git develop | awk '{ print $1 }')
+          echo "CL_HASH=${HASH}" >> $GITHUB_ENV
+
+      - name: Write hash
+        uses: ./.github/actions/write-hash
+        with:
+          hash: ${{ env.CL_HASH }}
+          file: ./control-libraries-hash
+          ci_branch: ci
+
   build-publish-galactic-control-libraries:
     needs: build-publish-galactic-workspace
     runs-on: ubuntu-latest
@@ -88,6 +100,18 @@ jobs:
           base_tag: galactic-devel
           modulo_branch: develop
           secret: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get modulo hash
+        run: |
+          HASH=$(git ls-remote https://github.com/epfl-lasa/modulo.git develop | awk '{ print $1 }')
+          echo "MODULO_HASH=${HASH}" >> $GITHUB_ENV
+
+      - name: Write hash
+        uses: ./.github/actions/write-hash
+        with:
+          hash: ${{ env.MODULO_HASH }}
+          file: ./modulo-hash
+          ci_branch: ci
 
   build-publish-galactic-modulo:
     needs: build-publish-galactic-control-libraries

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -7,9 +7,26 @@ on:
       - main
   workflow_dispatch:
 
+env:
+  CI_BRANCH: 'ci'
+
 jobs:
 
+  create-new-ci-branch:
+    runs-on: ubuntu-latest
+    name: Create new ci branch from main
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Recreate ci branch
+        run: |
+          git config user.name github-actions
+          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
+          git checkout -b ${{ env.CI_BRANCH }} && git push -f -u origin ${{ env.CI_BRANCH }}
+
   build-publish-galactic-workspace:
+    needs: create-new-ci-branch
     runs-on: ubuntu-latest
     name: Build and publish ROS2 galactic workspace image
     steps:

--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -98,6 +98,7 @@ jobs:
           secret: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Write hash to file and push to ci branch
+        if: ${{ needs.check-hash.outputs.modulo_rebuild == 'true' }}
         uses: ./.github/actions/write-hash
         with:
           hash: ${{ needs.check-hash.outputs.modulo_id }}

--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -57,12 +57,13 @@ jobs:
     needs: check-hash
     runs-on: ubuntu-latest
     name: Rebuild ros2-control-libraries image
-    if: ${{ needs.check-hash.outputs.cl_rebuild == 'true' }}
     steps:
       - name: Checkout repository
+        if: ${{ needs.check-hash.outputs.cl_rebuild == 'true' }}
         uses: actions/checkout@v2
 
       - name: Build new ros2-control-libraries galactic image
+        if: ${{ needs.check-hash.outputs.cl_rebuild == 'true' }}
         uses: ./.github/actions/build-push
         with:
           workspace: ros2-control-libraries
@@ -83,9 +84,7 @@ jobs:
     needs: [check-hash, rebuild-cl-image]
     runs-on: ubuntu-latest
     name: Rebuild ros2-modulo image
-    if: |
-      ${{ needs.check-hash.outputs.cl_rebuild == 'true' }} ||
-      ${{ needs.check-hash.outputs.modulo_rebuild == 'true' }}
+    if: needs.check-hash.outputs.cl_rebuild == 'true' || needs.check-hash.outputs.modulo_rebuild == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -109,9 +108,7 @@ jobs:
     needs: [ check-hash, rebuild-cl-image, rebuild-modulo-image ]
     runs-on: ubuntu-latest
     name: Rebuild ros2-modulo-control image
-    if: |
-      ${{ needs.check-hash.outputs.cl_rebuild == 'true' }} ||
-      ${{ needs.check-hash.outputs.modulo_rebuild == 'true' }}
+    if: needs.check-hash.outputs.cl_rebuild == 'true' || needs.check-hash.outputs.modulo_rebuild == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -31,7 +31,7 @@ jobs:
           NEW_HASH=$(git ls-remote https://github.com/epfl-lasa/control-libraries.git develop | awk '{ print $1 }')
           OLD_HASH=$(cat ./control-libraries-hash || echo '')
           if [ "${NEW_HASH}" = "${OLD_HASH}" ]; then
-            echo "The ros2-control-libraries image is up to date."
+            echo "Control libraries doesn't have new commits."
             echo "::set-output name=rebuild::false"
           else
             echo "Control libraries have new commits, rebuilding image now..."
@@ -45,7 +45,7 @@ jobs:
           NEW_HASH=$(git ls-remote https://github.com/epfl-lasa/modulo.git develop | awk '{ print $1 }')
           OLD_HASH=$(cat ./modulo-hash || echo '')
           if [ "${NEW_HASH}" = "${OLD_HASH}" ]; then
-            echo "The ros2-modulo image is up to date."
+            echo "Modulo doesn't have new commits."
             echo "::set-output name=rebuild::false"
           else
             echo "Modulo has new commits, rebuilding image now..."

--- a/.github/workflows/check-upstream.yml
+++ b/.github/workflows/check-upstream.yml
@@ -13,7 +13,7 @@ jobs:
 
   check-hash:
     runs-on: ubuntu-latest
-    name: Check latest hash on control libraries
+    name: Check latest hashes on control libraries and modulo
     outputs:
       cl_id: ${{ steps.check_cl.outputs.id }}
       cl_rebuild: ${{ steps.check_cl.outputs.rebuild }}
@@ -71,6 +71,14 @@ jobs:
           output_tag: galactic-devel
           secret: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Write hash to file and push to ci branch
+        if: ${{ needs.check-hash.outputs.cl_rebuild == 'true' }}
+        uses: ./.github/actions/write-hash
+        with:
+          hash: ${{ needs.check-hash.outputs.cl_id }}
+          file: './control-libraries-hash'
+          ci_branch: ${{ env.CI_BRANCH }}
+
   rebuild-modulo-image:
     needs: [check-hash, rebuild-cl-image]
     runs-on: ubuntu-latest
@@ -90,6 +98,13 @@ jobs:
           modulo_branch: develop
           secret: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Write hash to file and push to ci branch
+        uses: ./.github/actions/write-hash
+        with:
+          hash: ${{ needs.check-hash.outputs.modulo_id }}
+          file: './modulo-hash'
+          ci_branch: ${{ env.CI_BRANCH }}
+
   rebuild-modulo-control-image:
     needs: [ check-hash, rebuild-cl-image, rebuild-modulo-image ]
     runs-on: ubuntu-latest
@@ -107,23 +122,3 @@ jobs:
           workspace: ros2-modulo-control
           base_tag: galactic-devel
           secret: ${{ secrets.GITHUB_TOKEN }}
-
-  write-hash:
-    needs: [check-hash, rebuild-cl-image, rebuild-modulo-image, rebuild-modulo-control-image]
-    runs-on: ubuntu-latest
-    name: Write new hashes to file
-    steps:
-      - name: Checkout CI branch
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ env.CI_BRANCH }}
-
-      - name: Write new hash to file and push to 'ci' branch
-        run: |
-          git config user.name github-actions
-          git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-          git fetch && git checkout main && git pull && git checkout ci && git rebase
-          echo ${{ needs.check-hash.outputs.cl_id }} > ./control-libraries-hash
-          echo ${{ needs.check-hash.outputs.modulo_id }} > ./modulo-hash
-          git add ./control-libraries-hash ./modulo-hash
-          git commit -m "Update upstream hashes" && git push


### PR DESCRIPTION
Another fix I want to merge before #36, review by commit:

Recreate CI branch on push on main: Each time there is a push on main, the CI branch is recreated to delete the possibly long commit history from it and to avoid rebasing conflicts.

Add action to write hash to file: I created a new action that logs in as github user and writes a desired hash to file, mostly to reduce code duplication

Fix if conditions in upstream workflow: I had to move around some if conditions in the upstream checking workflow because if the control libraries rebuild doesn't run at all, the modulo rebuild will never run either, which is not desired because only modulo might change.