### PR TITLE
Set cron correctly for check upstream main

### DIFF
--- a/.github/workflows/check-upstream-main.yml
+++ b/.github/workflows/check-upstream-main.yml
@@ -3,7 +3,7 @@ name: Check for updated upstream libraries (main branches)
 # Run scheduled workflow
 on:
   schedule:
-   - cron: '* 4 * * 1,4' # corresponds to Wednesday and Saturday
+   - cron: '05 4 * * 1,4' # corresponds to Wednesday and Saturday
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
Just a small fix to a scheduled action. I saw that it ran 5 times instead of just once so I realized that I need to set a minute of the hour, otherwise it will run as many times as it can during the desired hour.