### PR TITLE
Set branch defaults consistent with image tags

### DIFF
--- a/ros2_control_libraries/build.sh
+++ b/ros2_control_libraries/build.sh
@@ -6,7 +6,7 @@ LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros2-ws
 BASE_TAG=galactic
 OUTPUT_TAG=galactic
-CL_BRANCH=develop
+CL_BRANCH=main
 
 BUILD_FLAGS=()
 while [ "$#" -gt 0 ]; do

--- a/ros2_modulo/build.sh
+++ b/ros2_modulo/build.sh
@@ -6,7 +6,7 @@ LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros2-control-libraries
 BASE_TAG=galactic
 OUTPUT_TAG=galactic
-MODULO_BRANCH=develop
+MODULO_BRANCH=main
 
 BUILD_FLAGS=()
 while [ "$#" -gt 0 ]; do

--- a/ros_control_libraries/build.sh
+++ b/ros_control_libraries/build.sh
@@ -6,7 +6,7 @@ LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros-ws
 BASE_TAG=noetic
 OUTPUT_TAG=noetic
-CL_BRANCH=develop
+CL_BRANCH=main
 
 BUILD_FLAGS=()
 while [ "$#" -gt 0 ]; do


### PR DESCRIPTION
As we discussed, there is a minor inconsistency in the default branches and tags in the build scripts. Even though I'm a big fan of using develop, I think we should go for main as the default here, as it corresponds to the `galactic` tag of our images. Also, this is on main branch of this repository, so main all the way :smile: 