### PR TITLE
Colcon build with Minimum Size Release

### DIFF
--- a/ros2_ws/config/colcon_defaults.yaml
+++ b/ros2_ws/config/colcon_defaults.yaml
@@ -1,7 +1,7 @@
 {
   "build": {
     "cmake-args": [
-      "-DCMAKE_BUILD_TYPE=RelWithDebInfo"
+      "-DCMAKE_BUILD_TYPE=MinSizeRel"
     ]
   }
 }


### PR DESCRIPTION
* Instead of RelWithDebInfo, build in minimum size release.
Otherwise, the final images will be twice as large.

@domire8 