### PR TITLE
Check for both default ed25519 and RSA SSH files and exit if not found

### DIFF
--- a/scripts/src/server.sh
+++ b/scripts/src/server.sh
@@ -133,11 +133,14 @@ if [ -z "$CONTAINER_NAME" ]; then
 fi
 
 if [[ ! -f "${SSH_KEY_FILE}" ]]; then
+  if [[ "${SSH_KEY_FILE}" != "${DEFAULT_SSH_ED25519}" ]]; then
+    echo "Provided SSH key file ${SSH_KEY_FILE} does not exist."
+    exit 1
+  fi
   if [[ ! -f "${DEFAULT_SSH_RSA}" ]]; then
     echo "SSH not set up! Configure SSH on your system."
     exit 1
   fi
-  echo "Provided SSH key file ${SSH_KEY_FILE} does not exist. Using default ${DEFAULT_SSH_RSA}"
   SSH_KEY_FILE="${DEFAULT_SSH_RSA}"
 fi
 PUBLIC_KEY=$(cat "${SSH_KEY_FILE}")

--- a/scripts/src/server.sh
+++ b/scripts/src/server.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
 SSH_PORT=3333
-SSH_KEY_FILE="$HOME/.ssh/id_rsa.pub"
+DEFAULT_SSH_RSA="$HOME/.ssh/id_rsa.pub"
+DEFAULT_SSH_ED25519="$HOME/.ssh/id_ed25519.pub"
+SSH_KEY_FILE="${DEFAULT_SSH_ED25519}"
 IMAGE_NAME=""
 USERNAME=root
 GPUS=""
@@ -130,6 +132,14 @@ if [ -z "$CONTAINER_NAME" ]; then
   CONTAINER_NAME="${CONTAINER_NAME/:/-}-ssh"
 fi
 
+if [[ ! -f "${SSH_KEY_FILE}" ]]; then
+  if [[ ! -f "${DEFAULT_SSH_RSA}" ]]; then
+    echo "SSH not set up! Configure SSH on your system."
+    exit 1
+  fi
+  echo "Provided SSH key file ${SSH_KEY_FILE} does not exist."
+  exit 1
+fi
 PUBLIC_KEY=$(cat "${SSH_KEY_FILE}")
 
 COMMAND_FLAGS=()

--- a/scripts/src/server.sh
+++ b/scripts/src/server.sh
@@ -3,7 +3,7 @@
 SSH_PORT=3333
 DEFAULT_SSH_RSA="$HOME/.ssh/id_rsa.pub"
 DEFAULT_SSH_ED25519="$HOME/.ssh/id_ed25519.pub"
-SSH_KEY_FILE="${DEFAULT_SSH_ED25519}"
+SSH_KEY_FILE="${DEFAULT_SSH_RSA}"
 IMAGE_NAME=""
 USERNAME=root
 GPUS=""
@@ -133,11 +133,11 @@ if [ -z "$CONTAINER_NAME" ]; then
 fi
 
 if [[ ! -f "${SSH_KEY_FILE}" ]]; then
-  if [[ "${SSH_KEY_FILE}" != "${DEFAULT_SSH_ED25519}" ]]; then
+  if [[ "${SSH_KEY_FILE}" != "${DEFAULT_SSH_RSA}" ]]; then
     echo "Provided SSH key file ${SSH_KEY_FILE} does not exist."
     exit 1
   fi
-  if [[ ! -f "${DEFAULT_SSH_RSA}" ]]; then
+  if [[ ! -f "${DEFAULT_SSH_ED25519}" ]]; then
     echo "SSH not set up! Configure SSH on your system."
     exit 1
   fi

--- a/scripts/src/server.sh
+++ b/scripts/src/server.sh
@@ -141,7 +141,7 @@ if [[ ! -f "${SSH_KEY_FILE}" ]]; then
     echo "SSH not set up! Configure SSH on your system."
     exit 1
   fi
-  SSH_KEY_FILE="${DEFAULT_SSH_RSA}"
+  SSH_KEY_FILE="${DEFAULT_SSH_ED25519}"
 fi
 PUBLIC_KEY=$(cat "${SSH_KEY_FILE}")
 

--- a/scripts/src/server.sh
+++ b/scripts/src/server.sh
@@ -137,8 +137,8 @@ if [[ ! -f "${SSH_KEY_FILE}" ]]; then
     echo "SSH not set up! Configure SSH on your system."
     exit 1
   fi
-  echo "Provided SSH key file ${SSH_KEY_FILE} does not exist."
-  exit 1
+  echo "Provided SSH key file ${SSH_KEY_FILE} does not exist. Using default ${DEFAULT_SSH_RSA}"
+  SSH_KEY_FILE="${DEFAULT_SSH_RSA}"
 fi
 PUBLIC_KEY=$(cat "${SSH_KEY_FILE}")
 


### PR DESCRIPTION
This PR adds the checking of the existence of the provided SSH key file in the `server.sh` scripts as well as consider both `ed25519` and `rsa` files as default.