### PR TITLE
Replace ros_version with base_tag to fix action

### DIFF
--- a/.github/actions/build-push/action.yml
+++ b/.github/actions/build-push/action.yml
@@ -5,8 +5,8 @@ inputs:
     description: 'The desired workspace'
     required: true
     default: 'ros2-ws'
-  ros_version:
-    description: 'The ROS distribution to use'
+  base_tag:
+    description: 'The tag of the base image to use'
     required: false
     default: 'galactic'
   cl_branch:
@@ -17,10 +17,6 @@ inputs:
     description: 'The branch of modulo'
     required: false
     default: 'main'
-  base_tag:
-    description: 'The tag of the base image to use (if left empty, the tag is the ROS version)'
-    required: false
-    default: ''
   output_tag:
     description: 'The tag for the output image (if left empty, the base tag is used)'
     required: false
@@ -47,9 +43,6 @@ runs:
 
         BASE_TAG=${{ inputs.base_tag }}
         OUTPUT_TAG=${{ inputs.output_tag }}
-        if [ -z ${BASE_TAG} ]; then
-          BASE_TAG=${{ inputs.ros_version }}
-        fi
         echo "::debug::Using base image tag ${BASE_TAG}"
         echo "BASE_TAG=${BASE_TAG}" >> $GITHUB_ENV
 

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -37,7 +37,7 @@ jobs:
         uses: ./.github/actions/build-push
         with:
           workspace: ros2-ws
-          ros_version: galactic
+          base_tag: galactic
           ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
 
@@ -53,7 +53,7 @@ jobs:
         uses: ./.github/actions/build-push
         with:
           workspace: ros2-control-libraries
-          ros_version: galactic
+          base_tag: galactic
           cl_branch: develop
           output_tag: galactic-devel
           ci_branch: ${{ env.CI_BRANCH }}
@@ -83,7 +83,7 @@ jobs:
         uses: ./.github/actions/build-push
         with:
           workspace: ros2-control-libraries
-          ros_version: galactic
+          base_tag: galactic
           cl_branch: main
           ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
@@ -141,7 +141,7 @@ jobs:
         uses: ./.github/actions/build-push
         with:
           workspace: ros2-modulo
-          ros_version: galactic
+          base_tag: galactic
           modulo_branch: main
           ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
@@ -186,6 +186,6 @@ jobs:
         uses: ./.github/actions/build-push
         with:
           workspace: ros2-modulo-control
-          ros_version: galactic
+          base_tag: galactic
           ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-upstream-devel.yml
+++ b/.github/workflows/check-upstream-devel.yml
@@ -67,7 +67,7 @@ jobs:
         uses: ./.github/actions/build-push
         with:
           workspace: ros2-control-libraries
-          ros_version: galactic
+          base_tag: galactic
           cl_branch: develop
           output_tag: galactic-devel
           ci_branch: ${{ env.CI_BRANCH }}

--- a/.github/workflows/check-upstream-main.yml
+++ b/.github/workflows/check-upstream-main.yml
@@ -67,9 +67,8 @@ jobs:
         uses: ./.github/actions/build-push
         with:
           workspace: ros2-control-libraries
-          ros_version: galactic
+          base_tag: galactic
           cl_branch: main
-          output_tag: galactic
           ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/manual-dispatch.yml
+++ b/.github/workflows/manual-dispatch.yml
@@ -7,8 +7,8 @@ on:
       workspace:
         description: 'The desired workspace (e.g. ros2-control-libraries)'
         required: true
-      ros_version:
-        description: 'The ROS distribution to use'
+      base_tag:
+        description: 'The tag of the base image to use'
         required: false
         default: 'galactic'
       cl_branch:
@@ -19,10 +19,6 @@ on:
         description: 'The branch of modulo'
         required: false
         default: 'main'
-      base_tag:
-        description: 'The tag of the base image to use (if left empty, the tag is the ROS version)'
-        required: false
-        default: ''
       output_tag:
         description: 'The tag for the output image (if left empty, the base tag is used)'
         required: false
@@ -47,10 +43,9 @@ jobs:
         uses: ./.github/actions/build-push
         with:
           workspace: ${{ github.event.inputs.workspace }}
-          ros_version: ${{ github.event.inputs.ros_version }}
+          base_tag: ${{ github.event.inputs.base_tag }}
           cl_branch: ${{ github.event.inputs.cl_branch }}
           modulo_branch: ${{ github.event.inputs.modulo_branch }}
-          base_tag: ${{ github.event.inputs.base_tag }}
           output_tag: ${{ github.event.inputs.output_tag }}
           write_image_hash: ${{ github.event.inputs.write_image_hash }}
           ci_branch: ${{ env.CI_BRANCH }}

--- a/ros2_ws/Dockerfile
+++ b/ros2_ws/Dockerfile
@@ -1,5 +1,5 @@
-ARG ROS_VERSION=galactic
-FROM ros:${ROS_VERSION} as base-dependencies
+ARG BASE_TAG=galactic
+FROM ros:${BASE_TAG} as base-dependencies
 ENV DEBIAN_FRONTEND=noninteractive
 
 # disable suggested and recommended install

--- a/ros2_ws/build.sh
+++ b/ros2_ws/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 IMAGE_NAME=aica-technology/ros2-ws
-ROS_VERSION=galactic
+BASE_TAG=galactic
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 if [[ ! -f "${SCRIPT_DIR}"/config/sshd_entrypoint.sh ]]; then
@@ -12,8 +12,8 @@ fi
 BUILD_FLAGS=()
 while [ "$#" -gt 0 ]; do
   case "$1" in
-  --ros-version)
-    ROS_VERSION=$2
+  --base-tag)
+    BASE_TAG=$2
     shift 2
     ;;
   -r | --rebuild)
@@ -31,8 +31,8 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-docker pull "ros:${ROS_VERSION}"
-BUILD_FLAGS+=(--build-arg ROS_VERSION="${ROS_VERSION}")
+docker pull "ros:${BASE_TAG}"
+BUILD_FLAGS+=(--build-arg BASE_TAG="${BASE_TAG}")
 
 if [[ "$OSTYPE" != "darwin"* ]]; then
   USER_ID="$(id -u "${USER}")"
@@ -41,6 +41,6 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
   BUILD_FLAGS+=(--build-arg GID="${GROUP_ID}")
 fi
 
-BUILD_FLAGS+=(-t "${IMAGE_NAME}":"${ROS_VERSION}")
+BUILD_FLAGS+=(-t "${IMAGE_NAME}":"${BASE_TAG}")
 
 DOCKER_BUILDKIT=1 docker build "${BUILD_FLAGS[@]}" .

--- a/ros_ws/Dockerfile
+++ b/ros_ws/Dockerfile
@@ -1,5 +1,5 @@
-ARG ROS_VERSION=noetic
-FROM ros:${ROS_VERSION} as base-dependencies
+ARG BASE_TAG=noetic
+FROM ros:${BASE_TAG} as base-dependencies
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y \

--- a/ros_ws/build.sh
+++ b/ros_ws/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 IMAGE_NAME=aica-technology/ros-ws
-ROS_VERSION=noetic
+BASE_TAG=noetic
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 if [[ ! -f "${SCRIPT_DIR}"/config/sshd_entrypoint.sh ]]; then
@@ -12,8 +12,8 @@ fi
 BUILD_FLAGS=()
 while [ "$#" -gt 0 ]; do
   case "$1" in
-  --ros-version)
-    ROS_VERSION=$2
+  --base-tag)
+    BASE_TAG=$2
     shift 2
     ;;
   -r | --rebuild)
@@ -31,8 +31,8 @@ while [ "$#" -gt 0 ]; do
   esac
 done
 
-docker pull "ros:${ROS_VERSION}"
-BUILD_FLAGS+=(--build-arg ROS_VERSION="${ROS_VERSION}")
+docker pull "ros:${BASE_TAG}"
+BUILD_FLAGS+=(--build-arg BASE_TAG="${BASE_TAG}")
 
 if [[ "$OSTYPE" != "darwin"* ]]; then
   USER_ID="$(id -u "${USER}")"
@@ -41,6 +41,6 @@ if [[ "$OSTYPE" != "darwin"* ]]; then
   BUILD_FLAGS+=(--build-arg GID="${GROUP_ID}")
 fi
 
-BUILD_FLAGS+=(-t "${IMAGE_NAME}":"${ROS_VERSION}")
+BUILD_FLAGS+=(-t "${IMAGE_NAME}":"${BASE_TAG}")
 
 DOCKER_BUILDKIT=1 docker build "${BUILD_FLAGS[@]}" .


### PR DESCRIPTION
As we found out, the workflows were providing a `BASE_TAG` to the docker build stage but for the `ros(2)_ws` the Dockerfiles needed a `ROS_VERSION`. For consistency, I changed everything to `BASE_TAG` and nothing needs the ros version anymore.