### PR TITLE
Place modulo packages in src/modulo directory

### DIFF
--- a/ros2_modulo/Dockerfile
+++ b/ros2_modulo/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /tmp
 RUN git clone -b ${MODULO_BRANCH} --depth 1 https://github.com/epfl-lasa/modulo.git
 
 # copy sources and build ROS workspace with user permissions
-RUN cp -r /tmp/modulo/source/ ${ROS2_WORKSPACE}/src
+RUN cp -r /tmp/modulo/source ${ROS2_WORKSPACE}/src/modulo
 
 WORKDIR ${ROS2_WORKSPACE}
 RUN /bin/bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash; colcon build"


### PR DESCRIPTION
When the source/ directory of modulo contains multiple packages (e.g. with the upcoming refactor), the line:
```
cp -r /tmp/modulo/source ${ROS2_WORKSPACE}/src
```
would result in some path `${ROS2_WORKSPACE}/src/source/modulo_core`, which is confusing and potentially dangerous. Instead, the collection of packages are explicitly grouped under a modulo parent folder.