### PR TITLE
Correctly escape ROS2_WORKSPACE variable in bashrc

### DIFF
--- a/ros2_ws/Dockerfile
+++ b/ros2_ws/Dockerfile
@@ -72,6 +72,9 @@ COPY --chown=${USER}:${USER} ./config/colcon ${COLCON_HOME}
 RUN /bin/bash ${COLCON_HOME}/setup.sh
 ENV COLCON_DEFAULTS_FILE ${COLCON_HOME}/defaults.yaml
 
+# set the default colcon workspace path
+ENV COLCON_WORKSPACE=${ROS2_WORKSPACE}
+
 # build ROS workspace
 RUN mkdir -p ${ROS2_WORKSPACE}/src
 WORKDIR ${ROS2_WORKSPACE}

--- a/ros2_ws/config/colcon/setup.sh
+++ b/ros2_ws/config/colcon/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # enable the colcon_cd utility
-echo "source /usr/share/colcon_cd/function/colcon_cd.sh; export _colcon_cd_root=${ROS2_WORKSPACE}" >> ~/.bashrc
+echo 'source /usr/share/colcon_cd/function/colcon_cd.sh; export _colcon_cd_root="${ROS2_WORKSPACE}"' >> ~/.bashrc
 
 # add aliases
 echo "alias cb='export ROS2_WORKSPACE; /bin/bash ${COLCON_HOME}/build.sh'" >> "${HOME}"/.bash_aliases

--- a/ros2_ws/config/colcon/setup.sh
+++ b/ros2_ws/config/colcon/setup.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # enable the colcon_cd utility
-echo 'source /usr/share/colcon_cd/function/colcon_cd.sh; export _colcon_cd_root="${ROS2_WORKSPACE}"' >> ~/.bashrc
+echo 'source /usr/share/colcon_cd/function/colcon_cd.sh; export _colcon_cd_root="${COLCON_WORKSPACE}"' >> ~/.bashrc
 
 # add aliases
 echo "alias cb='export ROS2_WORKSPACE; /bin/bash ${COLCON_HOME}/build.sh'" >> "${HOME}"/.bash_aliases


### PR DESCRIPTION
* Use single quotes to escape the variable written to bashrc so that the value is only expanded at the login step (at which point the value may have changed)

There was a small bug with #50 that I didn't catch until using the backend. When a downstream image (such as the component SDK or the AICA backend) creates an overlay workspace, redefining the `ROS2_WORKSPACE` variable, the colcon_cd path is not updated at login because the variable was already expanded directly in `bashrc`. Now it is written to file as the variable and only expanded at login.