### PR TITLE
Fix COLCON_WORKSPACE path in colcon utils

### DIFF
--- a/ros2_ws/config/colcon/build.sh
+++ b/ros2_ws/config/colcon/build.sh
@@ -9,10 +9,17 @@ whole workspace. Supply the following flags to modify the build.
 Any additional flags are forwarded to colcon build.
 
 -d | --debug            Set CMAKE_BUILD_TYPE to Debug.
+
 -o | --override         Add --allow-overriding for listed packages
+
+-c | --cd               Temporarily change into the COLCON_WORKSPACE
+                        directory when building
+                        (workspace path: ${COLCON_WORKSPACE})
+
 -h | --help             Show this help message.
 "
 
+CHANGE_DIR=false
 OVERRIDE=false
 PACKAGES=()
 BUILD_ARGS=()
@@ -24,6 +31,10 @@ while [ "$#" -gt 0 ]; do
     ;;
   -o | --override)
     OVERRIDE=true
+    shift 1
+    ;;
+  -c | --cd)
+    CHANGE_DIR=true
     shift 1
     ;;
   -h | --help)
@@ -44,7 +55,9 @@ done
 CURRENT_DIR=$(pwd)
 
 colcon_build_packages () {
-  cd "${COLCON_WORKSPACE}"
+  if [ "${CHANGE_DIR}" == true ]; then
+    cd "${COLCON_WORKSPACE}"
+  fi
   if [ ${#PACKAGES[@]} -gt 0 ]; then
     if [ "${OVERRIDE}" == true ]; then
       BUILD_ARGS+=(--allow-overriding "${PACKAGES[@]}")

--- a/ros2_ws/config/colcon/test.sh
+++ b/ros2_ws/config/colcon/test.sh
@@ -8,13 +8,22 @@ whole workspace. Supply the following flags to modify the test.
 
 Any additional flags are forwarded to colcon test.
 
+-c | --cd               Temporarily change into the COLCON_WORKSPACE
+                        directory when testing
+                        (workspace path: ${COLCON_WORKSPACE})
+
 -h | --help             Show this help message.
 "
 
+CHANGE_DIR=false
 PACKAGES=()
 TEST_ARGS=()
 while [ "$#" -gt 0 ]; do
   case "$1" in
+  -c | --cd)
+    CHANGE_DIR=true
+    shift 1
+    ;;
   -h | --help)
     echo "${HELP_MESSAGE}"
     exit 0
@@ -33,7 +42,9 @@ done
 CURRENT_DIR=$(pwd)
 
 colcon_test_packages () {
-  cd "${COLCON_WORKSPACE}"
+  if [ "${CHANGE_DIR}" == true ]; then
+    cd "${COLCON_WORKSPACE}"
+  fi
   if [ ${#PACKAGES[@]} -gt 0 ]; then
     colcon test --packages-select "${PACKAGES[@]}" "${TEST_ARGS[@]}"
   else


### PR DESCRIPTION
Well, I'm annoyed that this simple feature has caused about 6 PRs already, but there was one other bug I missed. As usual, it slipped under the radar when I was testing `cb` / `ct` on the `ros2_ws` image, but in the backend or other places with the overlay workspace it was always going to the base workspace.

To prevent unexpected behaviour, the default usage will still require you to `cd` into the appropriate workspace (overlay or underlay). When building overlay packages, the `-c | --cd` flag can be supplied to `cb` or `ct` so you can build from any directory.

@buschbapti @domire8 