### PR TITLE
Add humble images to workflows

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -236,7 +236,7 @@ jobs:
   build-publish-galactic-modulo-control-devel:
     needs: build-publish-galactic-modulo-devel
     runs-on: ubuntu-latest
-    name: Build and publish ROS2 galactic workspace image with modulo and ros2 control installed
+    name: Build and publish development ROS2 galactic workspace image with modulo and ros2 control installed
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -41,6 +41,22 @@ jobs:
           ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
 
+  build-publish-humble-workspace:
+    needs: create-new-ci-branch
+    runs-on: ubuntu-latest
+    name: Build and publish ROS2 humble workspace image
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build and Push
+        uses: ./.github/actions/build-push
+        with:
+          workspace: ros2-ws
+          base_tag: humble
+          ci_branch: ${{ env.CI_BRANCH }}
+          secret: ${{ secrets.GITHUB_TOKEN }}
+
   build-publish-galactic-control-libraries-devel:
     needs: build-publish-galactic-workspace
     runs-on: ubuntu-latest
@@ -69,6 +85,36 @@ jobs:
         with:
           hash: ${{ env.CL_DEVELOP_HASH }}
           file: ./control-libraries-develop-hash
+          ci_branch: ci
+
+  build-publish-humble-control-libraries-devel:
+    needs: build-publish-humble-workspace
+    runs-on: ubuntu-latest
+    name: Build and publish development ROS2 humble workspace image with control libraries installed
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build and Push
+        uses: ./.github/actions/build-push
+        with:
+          workspace: ros2-control-libraries
+          base_tag: humble
+          cl_branch: develop
+          output_tag: humble-devel
+          ci_branch: ${{ env.CI_BRANCH }}
+          secret: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get control libraries develop hash
+        run: |
+          HASH=$(git ls-remote https://github.com/epfl-lasa/control-libraries.git develop | awk '{ print $1 }')
+          echo "CL_DEVELOP_HASH=${HASH}" >> $GITHUB_ENV
+
+      - name: Write hash
+        uses: ./.github/actions/write-hash
+        with:
+          hash: ${{ env.CL_DEVELOP_HASH }}
+          file: ./control-libraries-humble-develop-hash
           ci_branch: ci
 
   build-publish-galactic-control-libraries:
@@ -129,6 +175,35 @@ jobs:
           file: ./modulo-develop-hash
           ci_branch: ci
 
+  build-publish-humble-modulo-devel:
+    needs: build-publish-humble-control-libraries-devel
+    runs-on: ubuntu-latest
+    name: Build and publish development ROS2 humble workspace image with modulo installed
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build and Push
+        uses: ./.github/actions/build-push
+        with:
+          workspace: ros2-modulo
+          base_tag: humble-devel
+          modulo_branch: develop
+          ci_branch: ${{ env.CI_BRANCH }}
+          secret: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get modulo develop hash
+        run: |
+          HASH=$(git ls-remote https://github.com/epfl-lasa/modulo.git develop | awk '{ print $1 }')
+          echo "MODULO_DEVELOP_HASH=${HASH}" >> $GITHUB_ENV
+
+      - name: Write hash
+        uses: ./.github/actions/write-hash
+        with:
+          hash: ${{ env.MODULO_DEVELOP_HASH }}
+          file: ./modulo-humble-develop-hash
+          ci_branch: ci
+
   build-publish-galactic-modulo:
     needs: build-publish-galactic-control-libraries
     runs-on: ubuntu-latest
@@ -171,6 +246,22 @@ jobs:
         with:
           workspace: ros2-modulo-control
           base_tag: galactic-devel
+          ci_branch: ${{ env.CI_BRANCH }}
+          secret: ${{ secrets.GITHUB_TOKEN }}
+
+  build-publish-humble-modulo-control-devel:
+    needs: build-publish-humble-modulo-devel
+    runs-on: ubuntu-latest
+    name: Build and publish ROS2 humble workspace image with modulo and ros2 control installed
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build and Push
+        uses: ./.github/actions/build-push
+        with:
+          workspace: ros2-modulo-control
+          base_tag: humble-devel
           ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/check-upstream-devel.yml
+++ b/.github/workflows/check-upstream-devel.yml
@@ -39,7 +39,7 @@ jobs:
             echo "::set-output name=id::${NEW_HASH}"
           fi
 
-      - name: Check lastest hash on modulo develop branch
+      - name: Check latest hash on modulo develop branch
         id: check_modulo
         run: |
           NEW_HASH=$(git ls-remote https://github.com/epfl-lasa/modulo.git develop | awk '{ print $1 }')
@@ -120,5 +120,75 @@ jobs:
         with:
           workspace: ros2-modulo-control
           base_tag: galactic-devel
+          ci_branch: ${{ env.CI_BRANCH }}
+          secret: ${{ secrets.GITHUB_TOKEN }}
+
+  rebuild-cl-humble-image:
+    needs: check-hash
+    runs-on: ubuntu-latest
+    name: Rebuild ros2-control-libraries image
+    steps:
+      - name: Checkout repository
+        if: ${{ needs.check-hash.outputs.cl_rebuild == 'true' }}
+        uses: actions/checkout@v2
+
+      - name: Build new ros2-control-libraries humble image
+        if: ${{ needs.check-hash.outputs.cl_rebuild == 'true' }}
+        uses: ./.github/actions/build-push
+        with:
+          workspace: ros2-control-libraries
+          base_tag: humble
+          cl_branch: develop
+          output_tag: humble-devel
+          ci_branch: ${{ env.CI_BRANCH }}
+          secret: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Write hash to file and push to ci branch
+        if: ${{ needs.check-hash.outputs.cl_rebuild == 'true' }}
+        uses: ./.github/actions/write-hash
+        with:
+          hash: ${{ needs.check-hash.outputs.cl_id }}
+          file: './control-libraries-humble-develop-hash'
+          ci_branch: ${{ env.CI_BRANCH }}
+
+  rebuild-modulo-humble-image:
+    needs: [ check-hash, rebuild-cl-humble-image ]
+    runs-on: ubuntu-latest
+    name: Rebuild ros2-modulo image
+    if: needs.check-hash.outputs.cl_rebuild == 'true' || needs.check-hash.outputs.modulo_rebuild == 'true'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build new ros2-modulo humble-devel image
+        uses: ./.github/actions/build-push
+        with:
+          workspace: ros2-modulo
+          base_tag: humble-devel
+          modulo_branch: develop
+          ci_branch: ${{ env.CI_BRANCH }}
+          secret: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Write hash to file and push to ci branch
+        if: ${{ needs.check-hash.outputs.modulo_rebuild == 'true' }}
+        uses: ./.github/actions/write-hash
+        with:
+          hash: ${{ needs.check-hash.outputs.modulo_id }}
+          file: './modulo-humble-develop-hash'
+          ci_branch: ${{ env.CI_BRANCH }}
+
+  rebuild-modulo-control-humble-image:
+    needs: [ check-hash, rebuild-cl-humble-image, rebuild-modulo-humble-image ]
+    runs-on: ubuntu-latest
+    name: Rebuild ros2-modulo-control image
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build new ros2-modulo-control humble-devel image
+        uses: ./.github/actions/build-push
+        with:
+          workspace: ros2-modulo-control
+          base_tag: humble-devel
           ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}

--- a/ros2_modulo_control/Dockerfile
+++ b/ros2_modulo_control/Dockerfile
@@ -1,9 +1,3 @@
-ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-modulo
-ARG BASE_TAG=galactic
-
-FROM ${BASE_IMAGE}:galactic as ros2-control-version-galactic
-USER ${USER}
-
 FROM ghcr.io/aica-technology/ros2-ws:galactic as ros2-control-sources-galactic
 USER ${USER}
 
@@ -22,15 +16,18 @@ RUN git clone -b galactic --depth 1 https://github.com/ros2/test_interface_files
 RUN git clone -b ros2 --depth 1 https://github.com/ros/angles.git
 
 
+ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-modulo
 FROM ${BASE_IMAGE}:galactic as ros2-control-version-galactic
 COPY --from=ros2-control-sources-galactic ${ROS2_WORKSPACE}/src/ros2_control/ ${ROS2_WORKSPACE}/src/
 
 
+ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-modulo
 FROM ${BASE_IMAGE}:galactic-devel as ros2-control-version-galactic-devel
 COPY --from=ros2-control-sources-galactic ${ROS2_WORKSPACE}/src/ros2_control/ ${ROS2_WORKSPACE}/src/
 
 
-FROM ${BASE_IMAGE}:humble as ros2-control-version-humble-devel
+ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-modulo
+FROM ${BASE_IMAGE}:humble-devel as ros2-control-version-humble-devel
 USER ${USER}
 
 WORKDIR /home/${USER}/ros2_ws/src

--- a/ros2_modulo_control/Dockerfile
+++ b/ros2_modulo_control/Dockerfile
@@ -1,3 +1,5 @@
+ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-modulo
+ARG BASE_TAG=galactic
 FROM ghcr.io/aica-technology/ros2-ws:galactic as ros2-control-sources-galactic
 USER ${USER}
 
@@ -16,17 +18,14 @@ RUN git clone -b galactic --depth 1 https://github.com/ros2/test_interface_files
 RUN git clone -b ros2 --depth 1 https://github.com/ros/angles.git
 
 
-ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-modulo
 FROM ${BASE_IMAGE}:galactic as ros2-control-version-galactic
 COPY --from=ros2-control-sources-galactic ${ROS2_WORKSPACE}/src/ros2_control/ ${ROS2_WORKSPACE}/src/
 
 
-ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-modulo
 FROM ${BASE_IMAGE}:galactic-devel as ros2-control-version-galactic-devel
 COPY --from=ros2-control-sources-galactic ${ROS2_WORKSPACE}/src/ros2_control/ ${ROS2_WORKSPACE}/src/
 
 
-ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-modulo
 FROM ${BASE_IMAGE}:humble-devel as ros2-control-version-humble-devel
 USER ${USER}
 
@@ -44,7 +43,6 @@ RUN git clone -b ros2 --depth 1 https://github.com/ros/angles.git
 RUN git clone -b ros2 --depth 1 https://github.com/ros-drivers/ackermann_msgs.git
 
 
-ARG BASE_TAG=galactic
 FROM ros2-control-version-${BASE_TAG} as final
 ENV ROS2_WORKSPACE /home/${USER}/ros2_ws
 WORKDIR ${ROS2_WORKSPACE}

--- a/ros2_modulo_control/Dockerfile
+++ b/ros2_modulo_control/Dockerfile
@@ -48,7 +48,7 @@ RUN git clone -b ros2 --depth 1 https://github.com/ros-drivers/ackermann_msgs.gi
 
 
 ARG BASE_TAG=galactic
-FROM ros2-control-version-${BASE_TAG} AS final
+FROM ros2-control-version-${BASE_TAG} as final
 ENV ROS2_WORKSPACE /home/${USER}/ros2_ws
 WORKDIR ${ROS2_WORKSPACE}
 RUN /bin/bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash; colcon build"

--- a/ros2_modulo_control/Dockerfile
+++ b/ros2_modulo_control/Dockerfile
@@ -1,13 +1,28 @@
 ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-modulo
 ARG BASE_TAG=galactic
 
-FROM ${BASE_IMAGE}:${BASE_TAG}
+FROM ${BASE_IMAGE}:galactic as ros2-control-version-galactic
 USER ${USER}
-ARG ROS2_CONTROL_TAG=2.11.0
 
 WORKDIR /home/${USER}/ros2_ws/src
-RUN git clone -b ${ROS2_CONTROL_TAG} --depth 1 https://github.com/ros-controls/ros2_control.git
-RUN git clone -b ${ROS2_CONTROL_TAG} --depth 1 https://github.com/ros-controls/ros2_controllers.git
+RUN git clone -b 1.0.0 --depth 1 https://github.com/ros-controls/ros2_control.git
+RUN git clone -b 1.0.0 --depth 1 https://github.com/ros-controls/ros2_controllers.git
+
+# get additional interface dependencies manually
+RUN git clone -b galactic-devel --depth 1 https://github.com/ros-controls/control_msgs.git
+RUN git clone -b ros2-master --depth 1 https://github.com/ros-controls/control_toolbox.git
+RUN git clone -b 2.1.1 --depth 1 https://github.com/ros-controls/realtime_tools.git
+RUN git clone -b galactic --depth 1 https://github.com/ros2/rcl_interfaces.git
+RUN git clone -b galactic --depth 1 https://github.com/ros2/test_interface_files.git
+RUN git clone -b ros2 --depth 1 https://github.com/ros/angles.git
+
+
+FROM ${BASE_IMAGE}:humble as ros2-control-version-humble
+USER ${USER}
+
+WORKDIR /home/${USER}/ros2_ws/src
+RUN git clone -b 2.11.0 --depth 1 https://github.com/ros-controls/ros2_control.git
+RUN git clone -b 2.11.0 --depth 1 https://github.com/ros-controls/ros2_controllers.git
 
 # get additional interface dependencies manually
 RUN git clone -b humble --depth 1 https://github.com/ros-controls/control_msgs.git
@@ -18,6 +33,9 @@ RUN git clone -b humble --depth 1 https://github.com/ros2/test_interface_files.g
 RUN git clone -b ros2 --depth 1 https://github.com/ros/angles.git
 RUN git clone -b ros2 --depth 1 https://github.com/ros-drivers/ackermann_msgs.git
 
+
+ARG BASE_TAG=galactic
+FROM ros2-control-version-${BASE_TAG} AS final
 ENV ROS2_WORKSPACE /home/${USER}/ros2_ws
 WORKDIR ${ROS2_WORKSPACE}
 RUN /bin/bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash; colcon build"

--- a/ros2_modulo_control/Dockerfile
+++ b/ros2_modulo_control/Dockerfile
@@ -4,7 +4,12 @@ ARG BASE_TAG=galactic
 FROM ${BASE_IMAGE}:galactic as ros2-control-version-galactic
 USER ${USER}
 
-WORKDIR /home/${USER}/ros2_ws/src
+FROM ghcr.io/aica-technology/ros2-ws:galactic as ros2-control-sources-galactic
+USER ${USER}
+
+RUN mkdir -p ${ROS2_WORKSPACE}/src/ros2_control
+WORKDIR ${ROS2_WORKSPACE}/src/ros2_control
+
 RUN git clone -b 1.0.0 --depth 1 https://github.com/ros-controls/ros2_control.git
 RUN git clone -b 1.0.0 --depth 1 https://github.com/ros-controls/ros2_controllers.git
 
@@ -17,7 +22,15 @@ RUN git clone -b galactic --depth 1 https://github.com/ros2/test_interface_files
 RUN git clone -b ros2 --depth 1 https://github.com/ros/angles.git
 
 
-FROM ${BASE_IMAGE}:humble as ros2-control-version-humble
+FROM ${BASE_IMAGE}:galactic as ros2-control-version-galactic
+COPY --from=ros2-control-sources-galactic ${ROS2_WORKSPACE}/src/ros2_control/ ${ROS2_WORKSPACE}/src/
+
+
+FROM ${BASE_IMAGE}:galactic-devel as ros2-control-version-galactic-devel
+COPY --from=ros2-control-sources-galactic ${ROS2_WORKSPACE}/src/ros2_control/ ${ROS2_WORKSPACE}/src/
+
+
+FROM ${BASE_IMAGE}:humble as ros2-control-version-humble-devel
 USER ${USER}
 
 WORKDIR /home/${USER}/ros2_ws/src

--- a/ros2_modulo_control/Dockerfile
+++ b/ros2_modulo_control/Dockerfile
@@ -3,19 +3,20 @@ ARG BASE_TAG=galactic
 
 FROM ${BASE_IMAGE}:${BASE_TAG}
 USER ${USER}
-ARG ROS2_CONTROL_TAG=1.0.0
+ARG ROS2_CONTROL_TAG=2.11.0
 
 WORKDIR /home/${USER}/ros2_ws/src
 RUN git clone -b ${ROS2_CONTROL_TAG} --depth 1 https://github.com/ros-controls/ros2_control.git
 RUN git clone -b ${ROS2_CONTROL_TAG} --depth 1 https://github.com/ros-controls/ros2_controllers.git
 
 # get additional interface dependencies manually
-RUN git clone -b galactic-devel --depth 1 https://github.com/ros-controls/control_msgs.git
+RUN git clone -b humble --depth 1 https://github.com/ros-controls/control_msgs.git
 RUN git clone -b ros2-master --depth 1 https://github.com/ros-controls/control_toolbox.git
-RUN git clone -b 2.1.1 --depth 1 https://github.com/ros-controls/realtime_tools.git
-RUN git clone -b galactic --depth 1 https://github.com/ros2/rcl_interfaces.git
-RUN git clone -b galactic --depth 1 https://github.com/ros2/test_interface_files.git
+RUN git clone -b 2.2.0 --depth 1 https://github.com/ros-controls/realtime_tools.git
+RUN git clone -b humble --depth 1 https://github.com/ros2/rcl_interfaces.git
+RUN git clone -b humble --depth 1 https://github.com/ros2/test_interface_files.git
 RUN git clone -b ros2 --depth 1 https://github.com/ros/angles.git
+RUN git clone -b ros2 --depth 1 https://github.com/ros-drivers/ackermann_msgs.git
 
 ENV ROS2_WORKSPACE /home/${USER}/ros2_ws
 WORKDIR ${ROS2_WORKSPACE}


### PR DESCRIPTION
I'm using here the same pattern for a two-way Dockerfile for ros2-modulo-control that we had before with foxy. After, I added all the humble-develop images to the relevant workflows so we get the latest develop images all the time. I find the main images unnecessary for now because they don't change often and we can build them ourselves if needed.