### PR TITLE
Add option to override docker run command

### DIFF
--- a/scripts/src/interactive.sh
+++ b/scripts/src/interactive.sh
@@ -24,6 +24,9 @@ Options:
                            aica-technology/ros2-ws:galactic would yield
                            aica-technology-ros2-ws-galactic-runtime
 
+  -c, --command <cmd>      Pass a command to execute in the container.
+                           (optional, default: ${COMMAND})
+
   -u, --user <user>        Specify the name of the login user.
                            (optional)
 
@@ -48,6 +51,7 @@ the 'docker run' command.
 
 RUN_FLAGS=()
 FWD_ARGS=()
+COMMAND=/bin/bash
 while [ "$#" -gt 0 ]; do
   case "$1" in
   -i | --image)
@@ -56,6 +60,10 @@ while [ "$#" -gt 0 ]; do
     ;;
   -n | --name)
     CONTAINER_NAME=$2
+    shift 2
+    ;;
+  -c | --command)
+    COMMAND=$2
     shift 2
     ;;
   --no-hostname)
@@ -138,4 +146,4 @@ docker run -it --rm \
   "${RUN_FLAGS[@]}" \
   --name "${CONTAINER_NAME}" \
   "${FWD_ARGS[@]}" \
-  "${IMAGE_NAME}" /bin/bash
+  "${IMAGE_NAME}" "${COMMAND}"

--- a/scripts/src/interactive.sh
+++ b/scripts/src/interactive.sh
@@ -6,6 +6,7 @@ USERNAME=""
 GPUS=""
 ROS_DOMAIN_ID=14
 GENERATE_HOST_NAME=true
+COMMAND=/bin/bash
 
 HELP_MESSAGE="
 Usage: aica-docker interactive <image> [-n <name>] [-u <user>]
@@ -51,7 +52,6 @@ the 'docker run' command.
 
 RUN_FLAGS=()
 FWD_ARGS=()
-COMMAND=/bin/bash
 while [ "$#" -gt 0 ]; do
   case "$1" in
   -i | --image)


### PR DESCRIPTION
* Instead of default /bin/bash, use a command variable with optional user override to allow greater flexibility. For example, the command may be to start an executable process when entering the container.

* Note that in the case of the default ROS entrypoint, the command is handled by an `exec` call, and therefore must be an executable file rather than a bash or shell command.

I tested this by writing a custom launch file along the lines of:
```bash
#!/bin/bash
source ${COLCON_WORKSPACE}/install/setup.bash; ros2 run my_package foo
# -> saved as /launch_foo.sh
```
I used COPY to get it in the docker image, and then passed the path as the new interactive command
```
aica-docker interactive my-foo-image -c  /launch_foo.sh
```

The ros2 process was started successfully with all output going to the interactive terminal. Stopping the process with CTRL-C also stopped the container.