### PR TITLE
Only write cl develop hash once

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -75,18 +75,6 @@ jobs:
           ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get control libraries develop hash
-        run: |
-          HASH=$(git ls-remote https://github.com/epfl-lasa/control-libraries.git develop | awk '{ print $1 }')
-          echo "CL_DEVELOP_HASH=${HASH}" >> $GITHUB_ENV
-
-      - name: Write hash
-        uses: ./.github/actions/write-hash
-        with:
-          hash: ${{ env.CL_DEVELOP_HASH }}
-          file: ./control-libraries-develop-hash
-          ci_branch: ci
-
   build-publish-humble-control-libraries-devel:
     needs: build-publish-humble-workspace
     runs-on: ubuntu-latest
@@ -105,6 +93,14 @@ jobs:
           ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
 
+  write-control-libraries-develop-hash:
+    needs: [ build-publish-galactic-control-libraries-devel, build-publish-humble-control-libraries-devel]
+    runs-on: ubuntu-latest
+    name: Write control libraries develop hash to file
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
       - name: Get control libraries develop hash
         run: |
           HASH=$(git ls-remote https://github.com/epfl-lasa/control-libraries.git develop | awk '{ print $1 }')
@@ -114,7 +110,7 @@ jobs:
         uses: ./.github/actions/write-hash
         with:
           hash: ${{ env.CL_DEVELOP_HASH }}
-          file: ./control-libraries-humble-develop-hash
+          file: ./control-libraries-develop-hash
           ci_branch: ci
 
   build-publish-galactic-control-libraries:

--- a/.github/workflows/check-upstream-devel.yml
+++ b/.github/workflows/check-upstream-devel.yml
@@ -89,14 +89,6 @@ jobs:
           ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Write hash to file and push to ci branch
-        if: ${{ needs.check-hash.outputs.cl_rebuild == 'true' }}
-        uses: ./.github/actions/write-hash
-        with:
-          hash: ${{ needs.check-hash.outputs.cl_id }}
-          file: './control-libraries-develop-hash'
-          ci_branch: ${{ env.CI_BRANCH }}
-
   rebuild-modulo-galactic-image:
     needs: [check-hash, rebuild-cl-galactic-image]
     runs-on: ubuntu-latest
@@ -160,14 +152,6 @@ jobs:
           ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Write hash to file and push to ci branch
-        if: ${{ needs.check-hash.outputs.cl_rebuild == 'true' }}
-        uses: ./.github/actions/write-hash
-        with:
-          hash: ${{ needs.check-hash.outputs.cl_id }}
-          file: './control-libraries-humble-develop-hash'
-          ci_branch: ${{ env.CI_BRANCH }}
-
   rebuild-modulo-humble-image:
     needs: [ check-hash, rebuild-cl-humble-image ]
     runs-on: ubuntu-latest
@@ -210,3 +194,19 @@ jobs:
           dockerfile_extension: .humble
           ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
+
+  write-cl-hash:
+    needs: [ rebuild-cl-galactic-image, rebuild-cl-humble-image ]
+    runs-on: ubuntu-latest
+    name: Write the control libraries hash to file
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Write hash to file and push to ci branch
+        if: ${{ needs.check-hash.outputs.cl_rebuild == 'true' }}
+        uses: ./.github/actions/write-hash
+        with:
+          hash: ${{ needs.check-hash.outputs.cl_id }}
+          file: './control-libraries-develop-hash'
+          ci_branch: ${{ env.CI_BRANCH }}


### PR DESCRIPTION
Not sure if those changes alone will solve our current issue, but it looks already better on my fork:
https://github.com/domire8/docker-images/actions/runs/3103639319

We currently write two files with the same control libraries develop hash, which is a bit unnecessary and might lead to problems in the CI