### PR TITLE
Copy development dependencies from corresponding image

### DIFF
--- a/.github/actions/build-push-multi-arch/action.yml
+++ b/.github/actions/build-push-multi-arch/action.yml
@@ -87,8 +87,11 @@ runs:
 
         if [[ "${BASE_TAG}" == *"galactic"* ]]; then
           UBUNTU_VERSION=focal-fossa
-        else
+        elif [[ "${BASE_TAG}" == *"humble"* ]]; then
           UBUNTU_VERSION=jammy-jellyfish
+        else
+          echo "::error::Invalid base tag. Base tag needs to contain either 'galactic' or 'humble'."
+          exit 1
         fi
 
         mkdir -p ${WORKSPACE_PATH}/config

--- a/.github/actions/build-push-multi-arch/action.yml
+++ b/.github/actions/build-push-multi-arch/action.yml
@@ -86,7 +86,7 @@ runs:
         DOCKERFILE=${WORKSPACE_PATH}/Dockerfile${{ inputs.dockerfile_extension }}
 
         if [[ "${BASE_TAG}" == *"galactic"* ]]; then
-          UBUNTU_VERSION=bionic-beaver
+          UBUNTU_VERSION=focal-fossa
         else
           UBUNTU_VERSION=jammy-jellyfish
         fi

--- a/.github/actions/build-push-multi-arch/action.yml
+++ b/.github/actions/build-push-multi-arch/action.yml
@@ -85,12 +85,19 @@ runs:
         IMAGE_NAME=${{ env.IMAGE_NAME }}
         DOCKERFILE=${WORKSPACE_PATH}/Dockerfile${{ inputs.dockerfile_extension }}
 
+        if [[ "${BASE_TAG}" == *"galactic"* ]]; then
+          UBUNTU_VERSION=bionic-beaver
+        else
+          UBUNTU_VERSION=jammy-jellyfish
+        fi
+
         mkdir -p ${WORKSPACE_PATH}/config
         cp common/sshd_entrypoint.sh ${WORKSPACE_PATH}/config/
         docker buildx build --file ${DOCKERFILE} \
           --platform=linux/arm64,linux/amd64 \
           --push --tag ghcr.io/${{ github.repository_owner }}/${IMAGE_NAME} \
           --build-arg BASE_TAG=${BASE_TAG} \
+          --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} \
           --build-arg CL_BRANCH=${{ inputs.cl_branch }} \
           --build-arg MODULO_BRANCH=${{ inputs.modulo_branch }} \
           ${WORKSPACE_PATH}

--- a/.github/actions/build-push/action.yml
+++ b/.github/actions/build-push/action.yml
@@ -73,7 +73,7 @@ runs:
         DOCKERFILE=${WORKSPACE_PATH}/Dockerfile${{ inputs.dockerfile_extension }}
         
         if [[ "${BASE_TAG}" == *"galactic"* ]]; then
-          UBUNTU_VERSION=bionic-beaver
+          UBUNTU_VERSION=focal-fossa
         else
           UBUNTU_VERSION=jammy-jellyfish
         fi

--- a/.github/actions/build-push/action.yml
+++ b/.github/actions/build-push/action.yml
@@ -74,8 +74,11 @@ runs:
         
         if [[ "${BASE_TAG}" == *"galactic"* ]]; then
           UBUNTU_VERSION=focal-fossa
-        else
+        elif [[ "${BASE_TAG}" == *"humble"* ]]; then
           UBUNTU_VERSION=jammy-jellyfish
+        else
+          echo "::error::Invalid base tag. Base tag needs to contain either 'galactic' or 'humble'."
+          exit 1
         fi
 
         mkdir -p ${WORKSPACE_PATH}/config

--- a/.github/actions/build-push/action.yml
+++ b/.github/actions/build-push/action.yml
@@ -71,11 +71,18 @@ runs:
         BASE_TAG=${{ env.BASE_TAG }}
         IMAGE_NAME=${{ env.IMAGE_NAME }}
         DOCKERFILE=${WORKSPACE_PATH}/Dockerfile${{ inputs.dockerfile_extension }}
+        
+        if [[ "${BASE_TAG}" == *"galactic"* ]]; then
+          UBUNTU_VERSION=bionic-beaver
+        else
+          UBUNTU_VERSION=jammy-jellyfish
+        fi
 
         mkdir -p ${WORKSPACE_PATH}/config
         cp common/sshd_entrypoint.sh ${WORKSPACE_PATH}/config/
         docker build ${WORKSPACE_PATH} --file ${DOCKERFILE} \
           --build-arg BASE_TAG=${BASE_TAG} \
+          --build-arg UBUNTU_VERSION=${UBUNTU_VERSION} \
           --build-arg CL_BRANCH=${{ inputs.cl_branch }} \
           --build-arg MODULO_BRANCH=${{ inputs.modulo_branch }} \
           --tag ${IMAGE_NAME}

--- a/ros2_control_libraries/Dockerfile
+++ b/ros2_control_libraries/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-ws
 ARG BASE_TAG=galactic
-ARG UBUNTU_VERSION=bionic-beaver
+ARG UBUNTU_VERSION=focal-fossa
 FROM ${BASE_IMAGE}:${BASE_TAG} as jammy-jellyfish
 
 # install development dependencies
@@ -8,7 +8,7 @@ COPY --from=ghcr.io/epfl-lasa/control-libraries/development-dependencies:22.04 /
 RUN sudo cp -R /tmp/local/* /usr/local && sudo rm -r /tmp/local
 
 
-FROM ${BASE_IMAGE}:${BASE_TAG} as bionic-beaver
+FROM ${BASE_IMAGE}:${BASE_TAG} as focal-fossa
 
 # install development dependencies
 COPY --from=ghcr.io/epfl-lasa/control-libraries/development-dependencies:20.04 /usr/local /tmp/local

--- a/ros2_control_libraries/Dockerfile
+++ b/ros2_control_libraries/Dockerfile
@@ -1,11 +1,22 @@
 ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-ws
 ARG BASE_TAG=galactic
-FROM ${BASE_IMAGE}:${BASE_TAG}
-WORKDIR ${HOME}
+ARG UBUNTU_VERSION=bionic-beaver
+FROM ${BASE_IMAGE}:${BASE_TAG} as jammy-jellyfish
 
 # install development dependencies
-COPY --from=ghcr.io/epfl-lasa/control-libraries/development-dependencies:latest /usr/local /tmp/local
+COPY --from=ghcr.io/epfl-lasa/control-libraries/development-dependencies:22.04 /usr/local /tmp/local
 RUN sudo cp -R /tmp/local/* /usr/local && sudo rm -r /tmp/local
+
+
+FROM ${BASE_IMAGE}:${BASE_TAG} as bionic-beaver
+
+# install development dependencies
+COPY --from=ghcr.io/epfl-lasa/control-libraries/development-dependencies:20.04 /usr/local /tmp/local
+RUN sudo cp -R /tmp/local/* /usr/local && sudo rm -r /tmp/local
+
+
+FROM ${UBUNTU_VERSION}
+WORKDIR ${HOME}
 
 RUN sudo ldconfig
 

--- a/ros2_control_libraries/build.sh
+++ b/ros2_control_libraries/build.sh
@@ -48,7 +48,14 @@ else
   docker pull "${BASE_IMAGE}:${BASE_TAG}"
 fi
 
+if [[ "${BASE_TAG}" == *"galactic"* ]]; then
+  UBUNTU_VERSION=bionic-beaver
+else
+  UBUNTU_VERSION=jammy-jellyfish
+fi
+
 BUILD_FLAGS+=(--build-arg BASE_TAG="${BASE_TAG}")
+BUILD_FLAGS+=(--build-arg UBUNTU_VERSION="${UBUNTU_VERSION}")
 BUILD_FLAGS+=(--build-arg CL_BRANCH="${CL_BRANCH}")
 BUILD_FLAGS+=(-t "${IMAGE_NAME}:${OUTPUT_TAG}")
 

--- a/ros2_control_libraries/build.sh
+++ b/ros2_control_libraries/build.sh
@@ -5,7 +5,7 @@ IMAGE_NAME=aica-technology/ros2-control-libraries
 LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros2-ws
 BASE_TAG=galactic
-OUTPUT_TAG=galactic
+OUTPUT_TAG=""
 CL_BRANCH=main
 
 BUILD_FLAGS=()
@@ -41,6 +41,11 @@ while [ "$#" -gt 0 ]; do
     ;;
   esac
 done
+
+if [ -z "${OUTPUT_TAG}" ]; then
+  echo "Output tag is empty, using the base tag as output tag."
+  OUTPUT_TAG="${BASE_TAG}"
+fi
 
 if [ "${LOCAL_BASE_IMAGE}" == true ]; then
   BUILD_FLAGS+=(--build-arg BASE_IMAGE=aica-technology/ros2-ws)

--- a/ros2_control_libraries/build.sh
+++ b/ros2_control_libraries/build.sh
@@ -49,7 +49,7 @@ else
 fi
 
 if [[ "${BASE_TAG}" == *"galactic"* ]]; then
-  UBUNTU_VERSION=bionic-beaver
+  UBUNTU_VERSION=focal-fossa
 else
   UBUNTU_VERSION=jammy-jellyfish
 fi

--- a/ros2_control_libraries/build.sh
+++ b/ros2_control_libraries/build.sh
@@ -50,8 +50,11 @@ fi
 
 if [[ "${BASE_TAG}" == *"galactic"* ]]; then
   UBUNTU_VERSION=focal-fossa
-else
+elif [[ "${BASE_TAG}" == *"humble"* ]]; then
   UBUNTU_VERSION=jammy-jellyfish
+else
+  echo "Invalid base tag. Base tag needs to contain either 'galactic' or 'humble'."
+  exit 1
 fi
 
 BUILD_FLAGS+=(--build-arg BASE_TAG="${BASE_TAG}")

--- a/ros2_modulo/build.sh
+++ b/ros2_modulo/build.sh
@@ -5,7 +5,7 @@ IMAGE_NAME=aica-technology/ros2-modulo
 LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros2-control-libraries
 BASE_TAG=galactic
-OUTPUT_TAG=galactic
+OUTPUT_TAG=""
 MODULO_BRANCH=main
 
 BUILD_FLAGS=()
@@ -41,6 +41,11 @@ while [ "$#" -gt 0 ]; do
     ;;
   esac
 done
+
+if [ -z "${OUTPUT_TAG}" ]; then
+  echo "Output tag is empty, using the base tag as output tag."
+  OUTPUT_TAG="${BASE_TAG}"
+fi
 
 if [ "${LOCAL_BASE_IMAGE}" = true ]; then
   BUILD_FLAGS+=(--build-arg BASE_IMAGE=aica-technology/ros2-control-libraries)

--- a/ros2_modulo_control/build.sh
+++ b/ros2_modulo_control/build.sh
@@ -48,8 +48,11 @@ BUILD_FLAGS+=(-t "${IMAGE_NAME}:${OUTPUT_TAG}")
 
 if [[ "${BASE_TAG}" == *"galactic"* ]]; then
   DOCKERFILE=Dockerfile.galactic
-else
+elif [[ "${BASE_TAG}" == *"humble"* ]]; then
   DOCKERFILE=Dockerfile.humble
+else
+  echo "Invalid base tag. Base tag needs to contain either 'galactic' or 'humble'."
+  exit 1
 fi
 
 DOCKER_BUILDKIT=1 docker build -f "${DOCKERFILE}" "${BUILD_FLAGS[@]}" .

--- a/ros2_modulo_control/build.sh
+++ b/ros2_modulo_control/build.sh
@@ -5,7 +5,7 @@ IMAGE_NAME=aica-technology/ros2-modulo-control
 LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros2-modulo
 BASE_TAG=galactic
-OUTPUT_TAG=galactic
+OUTPUT_TAG=""
 
 BUILD_FLAGS=()
 while [ "$#" -gt 0 ]; do
@@ -36,6 +36,11 @@ while [ "$#" -gt 0 ]; do
     ;;
   esac
 done
+
+if [ -z "${OUTPUT_TAG}" ]; then
+  echo "Output tag is empty, using the base tag as output tag."
+  OUTPUT_TAG="${BASE_TAG}"
+fi
 
 if [ "${LOCAL_BASE_IMAGE}" = true ]; then
   BUILD_FLAGS+=(--build-arg BASE_IMAGE=aica-technology/ros2-modulo)


### PR DESCRIPTION
This should fix problems with pinocchio that we have downstream in the controllers. Now that we have 20.04 and 22.04 development images on control libraries, we can copy the /usr/local directory from the corresponding image (galactic is 20.04 and humble 22.04).

One point to think about: Currently we have
```
if [[ "${BASE_TAG}" == *"galactic"* ]]; then
  UBUNTU_VERSION=bionic-beaver
else
  UBUNTU_VERSION=jammy-jellyfish
fi
```
so any tag that doesn't contain 'galactic' will be considered as a humble/22.04 image. Maybe we have to make sure that the tags actually contain either galactic or humble? To be extra safe.