### PR TITLE
Clean up workflows

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -184,20 +184,20 @@ jobs:
         with:
           workspace: ros2-modulo
           base_tag: humble-devel
-          modulo_branch: develop
+          modulo_branch: humble
           ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get modulo develop hash
+      - name: Get modulo humble hash
         run: |
-          HASH=$(git ls-remote https://github.com/epfl-lasa/modulo.git develop | awk '{ print $1 }')
-          echo "MODULO_DEVELOP_HASH=${HASH}" >> $GITHUB_ENV
+          HASH=$(git ls-remote https://github.com/epfl-lasa/modulo.git humble | awk '{ print $1 }')
+          echo "MODULO_HUMBLE_HASH=${HASH}" >> $GITHUB_ENV
 
       - name: Write hash
         uses: ./.github/actions/write-hash
         with:
-          hash: ${{ env.MODULO_DEVELOP_HASH }}
-          file: ./modulo-humble-develop-hash
+          hash: ${{ env.MODULO_HUMBLE_HASH }}
+          file: ./modulo-humble-hash
           ci_branch: ci
 
   build-publish-galactic-modulo:

--- a/.github/workflows/check-upstream-devel.yml
+++ b/.github/workflows/check-upstream-devel.yml
@@ -116,7 +116,7 @@ jobs:
           ci_branch: ${{ env.CI_BRANCH }}
 
   rebuild-modulo-control-galactic-image:
-    needs: [ check-hash, rebuild-cl-galactic-image, rebuild-modulo-galactic-image ]
+    needs: [ rebuild-modulo-galactic-image ]
     runs-on: ubuntu-latest
     name: Rebuild ros2-modulo-control galactic-devel image
     steps:
@@ -179,7 +179,7 @@ jobs:
           ci_branch: ${{ env.CI_BRANCH }}
 
   rebuild-modulo-control-humble-image:
-    needs: [ check-hash, rebuild-cl-humble-image, rebuild-modulo-humble-image ]
+    needs: [ rebuild-modulo-humble-image ]
     runs-on: ubuntu-latest
     name: Rebuild ros2-modulo-control humble-devel image
     steps:
@@ -196,15 +196,15 @@ jobs:
           secret: ${{ secrets.GITHUB_TOKEN }}
 
   write-cl-hash:
-    needs: [ rebuild-cl-galactic-image, rebuild-cl-humble-image ]
+    needs: [ check-hash, rebuild-cl-galactic-image, rebuild-cl-humble-image ]
     runs-on: ubuntu-latest
     name: Write the control libraries hash to file
+    if: needs.check-hash.outputs.cl_rebuild == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
       - name: Write hash to file and push to ci branch
-        if: ${{ needs.check-hash.outputs.cl_rebuild == 'true' }}
         uses: ./.github/actions/write-hash
         with:
           hash: ${{ needs.check-hash.outputs.cl_id }}

--- a/.github/workflows/check-upstream-main.yml
+++ b/.github/workflows/check-upstream-main.yml
@@ -108,7 +108,7 @@ jobs:
           ci_branch: ${{ env.CI_BRANCH }}
 
   rebuild-modulo-control-galactic-image:
-    needs: [ check-hash, rebuild-cl-galactic-image, rebuild-modulo-galactic-image ]
+    needs: [ rebuild-modulo-galactic-image ]
     runs-on: ubuntu-latest
     name: Rebuild ros2-modulo-control galactic image
     steps:


### PR DESCRIPTION
The workflows still had a couple of minor bugs:
- The build-push didn't use humble branch of modulo for the humble-devel image and wrote the hash to a weird file
- The job that writes the cl hash in check-upstream-devel was missing the dependency on the 'check-hash' job and could therefore not write the hash, resulting in constant rebuilding of all the devel images