### PR TITLE
Fix manual dispatch workflow and disable warnings from setuptools

### DIFF
--- a/.github/workflows/manual-dispatch.yml
+++ b/.github/workflows/manual-dispatch.yml
@@ -65,6 +65,7 @@ jobs:
           workspace: ${{ github.event.inputs.workspace }}
           base_tag: ${{ github.event.inputs.base_tag }}
           cl_branch: ${{ github.event.inputs.cl_branch }}
+          dockerfile_extension: ${{ github.event.inputs.dockerfile_extension }}
           modulo_branch: ${{ github.event.inputs.modulo_branch }}
           output_tag: ${{ github.event.inputs.output_tag }}
           write_image_hash: ${{ github.event.inputs.write_image_hash }}
@@ -78,6 +79,7 @@ jobs:
           workspace: ${{ github.event.inputs.workspace }}
           base_tag: ${{ github.event.inputs.base_tag }}
           cl_branch: ${{ github.event.inputs.cl_branch }}
+          dockerfile_extension: ${{ github.event.inputs.dockerfile_extension }}
           modulo_branch: ${{ github.event.inputs.modulo_branch }}
           output_tag: ${{ github.event.inputs.output_tag }}
           write_image_hash: ${{ github.event.inputs.write_image_hash }}

--- a/ros2_ws/Dockerfile
+++ b/ros2_ws/Dockerfile
@@ -1,6 +1,7 @@
 ARG BASE_TAG=galactic
 FROM ros:${BASE_TAG} as base-dependencies
 ENV DEBIAN_FRONTEND=noninteractive
+ENV PYTHONWARNINGS=ignore:::setuptools.command.install,ignore:::setuptools.command.easy_install,ignore:::pkg_resources
 
 # disable suggested and recommended install
 RUN apt-config dump | grep -we Recommends -e Suggests | sed s/1/0/ \


### PR DESCRIPTION
For the disabling of the python warnings, see [this issue](https://github.com/colcon/colcon-core/issues/454)