### PR TITLE
Remove config directory before committing

### DIFF
--- a/.github/actions/build-push-multi-arch/action.yml
+++ b/.github/actions/build-push-multi-arch/action.yml
@@ -104,6 +104,7 @@ runs:
           --build-arg CL_BRANCH=${{ inputs.cl_branch }} \
           --build-arg MODULO_BRANCH=${{ inputs.modulo_branch }} \
           ${WORKSPACE_PATH}
+        rm -rf ${WORKSPACE_PATH}/config
       shell: bash
 
     - name: Write new image hash to file

--- a/.github/actions/build-push/action.yml
+++ b/.github/actions/build-push/action.yml
@@ -89,6 +89,7 @@ runs:
           --build-arg CL_BRANCH=${{ inputs.cl_branch }} \
           --build-arg MODULO_BRANCH=${{ inputs.modulo_branch }} \
           --tag ${IMAGE_NAME}
+        rm -rf ${WORKSPACE_PATH}/config
       shell: bash
 
     - name: Login to GitHub Container Registry

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -111,7 +111,7 @@ jobs:
         with:
           hash: ${{ env.CL_DEVELOP_HASH }}
           file: ./control-libraries-develop-hash
-          ci_branch: ci
+          ci_branch: ${{ env.CI_BRANCH }}
 
   build-publish-galactic-control-libraries:
     needs: build-publish-galactic-workspace
@@ -140,7 +140,7 @@ jobs:
         with:
           hash: ${{ env.CL_MAIN_HASH }}
           file: ./control-libraries-main-hash
-          ci_branch: ci
+          ci_branch: ${{ env.CI_BRANCH }}
 
   build-publish-galactic-modulo-devel:
     needs: build-publish-galactic-control-libraries-devel
@@ -169,7 +169,7 @@ jobs:
         with:
           hash: ${{ env.MODULO_DEVELOP_HASH }}
           file: ./modulo-develop-hash
-          ci_branch: ci
+          ci_branch: ${{ env.CI_BRANCH }}
 
   build-publish-humble-modulo-devel:
     needs: build-publish-humble-control-libraries-devel
@@ -198,7 +198,7 @@ jobs:
         with:
           hash: ${{ env.MODULO_HUMBLE_HASH }}
           file: ./modulo-humble-hash
-          ci_branch: ci
+          ci_branch: ${{ env.CI_BRANCH }}
 
   build-publish-galactic-modulo:
     needs: build-publish-galactic-control-libraries
@@ -227,7 +227,7 @@ jobs:
         with:
           hash: ${{ env.MODULO_MAIN_HASH }}
           file: ./modulo-main-hash
-          ci_branch: ci
+          ci_branch: ${{ env.CI_BRANCH }}
 
   build-publish-galactic-modulo-control-devel:
     needs: build-publish-galactic-modulo-devel


### PR DESCRIPTION
Ok I'm getting a bit desperate here, the previous build and push workflow didn't succeed for the development modulo images and I can't really figure out why. While the build-push action works perfectly fine for most images, it fails sometimes, saying that there are no tracked changes but untracked files despite there being a commit on the CI branch with the desired hash.

So something else we can try is to remove the config directory again after the build stage such that it will not become an untracked change...