### PR TITLE
Build galactic, humble and humble-devel images

### DIFF
--- a/.github/actions/build-push-multi-arch/action.yml
+++ b/.github/actions/build-push-multi-arch/action.yml
@@ -104,7 +104,6 @@ runs:
           --build-arg CL_BRANCH=${{ inputs.cl_branch }} \
           --build-arg MODULO_BRANCH=${{ inputs.modulo_branch }} \
           ${WORKSPACE_PATH}
-        rm ${WORKSPACE_PATH}/config/sshd_entrypoint.sh
       shell: bash
 
     - name: Write new image hash to file
@@ -112,7 +111,7 @@ runs:
       run: |
         git config user.name github-actions
         git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-        git fetch origin ${{ inputs.ci_branch }} && git checkout ${{ inputs.ci_branch }} && git rebase origin/main
+        git fetch origin ${{ inputs.ci_branch }} && git checkout ${{ inputs.ci_branch }} && git reset --hard HEAD && git rebase origin/main
         SHA=$(docker images --no-trunc --quiet ${IMAGE_NAME})
         echo ${SHA} > ./${{ env.WORKSPACE_PATH }}/${{ env.OUTPUT_TAG }}-hash
         git add ./${{ env.WORKSPACE_PATH }}/${{ env.OUTPUT_TAG }}-hash

--- a/.github/actions/build-push-multi-arch/action.yml
+++ b/.github/actions/build-push-multi-arch/action.yml
@@ -104,7 +104,7 @@ runs:
           --build-arg CL_BRANCH=${{ inputs.cl_branch }} \
           --build-arg MODULO_BRANCH=${{ inputs.modulo_branch }} \
           ${WORKSPACE_PATH}
-        rm -rf ${WORKSPACE_PATH}/config
+        rm ${WORKSPACE_PATH}/config/sshd_entrypoint.sh
       shell: bash
 
     - name: Write new image hash to file

--- a/.github/actions/build-push/action.yml
+++ b/.github/actions/build-push/action.yml
@@ -89,7 +89,7 @@ runs:
           --build-arg CL_BRANCH=${{ inputs.cl_branch }} \
           --build-arg MODULO_BRANCH=${{ inputs.modulo_branch }} \
           --tag ${IMAGE_NAME}
-        rm -rf ${WORKSPACE_PATH}/config
+        rm ${WORKSPACE_PATH}/config/sshd_entrypoint.sh
       shell: bash
 
     - name: Login to GitHub Container Registry

--- a/.github/actions/build-push/action.yml
+++ b/.github/actions/build-push/action.yml
@@ -89,7 +89,6 @@ runs:
           --build-arg CL_BRANCH=${{ inputs.cl_branch }} \
           --build-arg MODULO_BRANCH=${{ inputs.modulo_branch }} \
           --tag ${IMAGE_NAME}
-        rm ${WORKSPACE_PATH}/config/sshd_entrypoint.sh
       shell: bash
 
     - name: Login to GitHub Container Registry
@@ -108,7 +107,7 @@ runs:
       run: |
         git config user.name github-actions
         git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-        git fetch origin ${{ inputs.ci_branch }} && git checkout ${{ inputs.ci_branch }} && git rebase origin/main
+        git fetch origin ${{ inputs.ci_branch }} && git checkout ${{ inputs.ci_branch }} && git reset --hard HEAD && git rebase origin/main
         SHA=$(docker images --no-trunc --quiet ${IMAGE_NAME})
         echo ${SHA} > ./${{ env.WORKSPACE_PATH }}/${{ env.OUTPUT_TAG }}-hash
         git add ./${{ env.WORKSPACE_PATH }}/${{ env.OUTPUT_TAG }}-hash

--- a/.github/actions/build-push/action.yml
+++ b/.github/actions/build-push/action.yml
@@ -12,7 +12,7 @@ inputs:
   base_tag:
     description: 'The tag of the base image to use'
     required: false
-    default: 'galactic'
+    default: 'humble'
   cl_branch:
     description: 'The branch of control libraries'
     required: false

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -57,10 +57,10 @@ jobs:
           ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
 
-  build-publish-galactic-control-libraries-devel:
+  build-publish-galactic-control-libraries:
     needs: build-publish-galactic-workspace
     runs-on: ubuntu-latest
-    name: Build and publish development ROS2 galactic workspace image with control libraries installed
+    name: Build and publish ROS2 galactic workspace image with control libraries installed
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -70,10 +70,46 @@ jobs:
         with:
           workspace: ros2-control-libraries
           base_tag: galactic
-          cl_branch: develop
-          output_tag: galactic-devel
+          cl_branch: main
           ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
+
+  build-publish-humble-control-libraries:
+    needs: build-publish-humble-workspace
+    runs-on: ubuntu-latest
+    name: Build and publish ROS2 humble workspace image with control libraries installed
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build and Push
+        uses: ./.github/actions/build-push-multi-arch
+        with:
+          workspace: ros2-control-libraries
+          base_tag: humble
+          cl_branch: main
+          ci_branch: ${{ env.CI_BRANCH }}
+          secret: ${{ secrets.GITHUB_TOKEN }}
+
+  write-control-libraries-main-hash:
+    needs: [ build-publish-galactic-control-libraries, build-publish-humble-control-libraries]
+    runs-on: ubuntu-latest
+    name: Write control libraries main hash to file
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Get control libraries main hash
+        run: |
+          HASH=$(git ls-remote https://github.com/epfl-lasa/control-libraries.git main | awk '{ print $1 }')
+          echo "CL_MAIN_HASH=${HASH}" >> $GITHUB_ENV
+
+      - name: Write hash
+        uses: ./.github/actions/write-hash
+        with:
+          hash: ${{ env.CL_MAIN_HASH }}
+          file: ./control-libraries-main-hash
+          ci_branch: ${{ env.CI_BRANCH }}
 
   build-publish-humble-control-libraries-devel:
     needs: build-publish-humble-workspace
@@ -93,14 +129,6 @@ jobs:
           ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
 
-  write-control-libraries-develop-hash:
-    needs: [ build-publish-galactic-control-libraries-devel, build-publish-humble-control-libraries-devel]
-    runs-on: ubuntu-latest
-    name: Write control libraries develop hash to file
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
       - name: Get control libraries develop hash
         run: |
           HASH=$(git ls-remote https://github.com/epfl-lasa/control-libraries.git develop | awk '{ print $1 }')
@@ -113,39 +141,10 @@ jobs:
           file: ./control-libraries-develop-hash
           ci_branch: ${{ env.CI_BRANCH }}
 
-  build-publish-galactic-control-libraries:
-    needs: build-publish-galactic-workspace
+  build-publish-galactic-modulo:
+    needs: build-publish-galactic-control-libraries
     runs-on: ubuntu-latest
-    name: Build and publish ROS2 galactic workspace image with control libraries installed
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Build and Push
-        uses: ./.github/actions/build-push-multi-arch
-        with:
-          workspace: ros2-control-libraries
-          base_tag: galactic
-          cl_branch: main
-          ci_branch: ${{ env.CI_BRANCH }}
-          secret: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get control libraries main hash
-        run: |
-          HASH=$(git ls-remote https://github.com/epfl-lasa/control-libraries.git main | awk '{ print $1 }')
-          echo "CL_MAIN_HASH=${HASH}" >> $GITHUB_ENV
-
-      - name: Write hash
-        uses: ./.github/actions/write-hash
-        with:
-          hash: ${{ env.CL_MAIN_HASH }}
-          file: ./control-libraries-main-hash
-          ci_branch: ${{ env.CI_BRANCH }}
-
-  build-publish-galactic-modulo-devel:
-    needs: build-publish-galactic-control-libraries-devel
-    runs-on: ubuntu-latest
-    name: Build and publish development ROS2 galactic workspace image with modulo installed
+    name: Build and publish ROS2 galactic workspace image with modulo installed
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -154,21 +153,21 @@ jobs:
         uses: ./.github/actions/build-push-multi-arch
         with:
           workspace: ros2-modulo
-          base_tag: galactic-devel
-          modulo_branch: develop
+          base_tag: galactic
+          modulo_branch: galactic
           ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Get modulo develop hash
+      - name: Get modulo galactic hash
         run: |
-          HASH=$(git ls-remote https://github.com/epfl-lasa/modulo.git develop | awk '{ print $1 }')
-          echo "MODULO_DEVELOP_HASH=${HASH}" >> $GITHUB_ENV
+          HASH=$(git ls-remote https://github.com/epfl-lasa/modulo.git galactic | awk '{ print $1 }')
+          echo "MODULO_GALACTIC_HASH=${HASH}" >> $GITHUB_ENV
 
       - name: Write hash
         uses: ./.github/actions/write-hash
         with:
-          hash: ${{ env.MODULO_DEVELOP_HASH }}
-          file: ./modulo-develop-hash
+          hash: ${{ env.MODULO_GALACTIC_HASH }}
+          file: ./modulo-galactic-hash
           ci_branch: ${{ env.CI_BRANCH }}
 
   build-publish-humble-modulo-devel:
@@ -200,10 +199,10 @@ jobs:
           file: ./modulo-humble-hash
           ci_branch: ${{ env.CI_BRANCH }}
 
-  build-publish-galactic-modulo:
-    needs: build-publish-galactic-control-libraries
+  build-publish-humble-modulo:
+    needs: build-publish-humble-control-libraries
     runs-on: ubuntu-latest
-    name: Build and publish ROS2 galactic workspace image with modulo installed
+    name: Build and publish ROS2 humble workspace image with modulo installed
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -212,7 +211,7 @@ jobs:
         uses: ./.github/actions/build-push-multi-arch
         with:
           workspace: ros2-modulo
-          base_tag: galactic
+          base_tag: humble
           modulo_branch: main
           ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
@@ -229,40 +228,6 @@ jobs:
           file: ./modulo-main-hash
           ci_branch: ${{ env.CI_BRANCH }}
 
-  build-publish-galactic-modulo-control-devel:
-    needs: build-publish-galactic-modulo-devel
-    runs-on: ubuntu-latest
-    name: Build and publish development ROS2 galactic workspace image with modulo and ros2 control installed
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Build and Push
-        uses: ./.github/actions/build-push-multi-arch
-        with:
-          workspace: ros2-modulo-control
-          base_tag: galactic-devel
-          dockerfile_extension: .galactic
-          ci_branch: ${{ env.CI_BRANCH }}
-          secret: ${{ secrets.GITHUB_TOKEN }}
-
-  build-publish-humble-modulo-control-devel:
-    needs: build-publish-humble-modulo-devel
-    runs-on: ubuntu-latest
-    name: Build and publish ROS2 humble workspace image with modulo and ros2 control installed
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Build and Push
-        uses: ./.github/actions/build-push-multi-arch
-        with:
-          workspace: ros2-modulo-control
-          base_tag: humble-devel
-          dockerfile_extension: .humble
-          ci_branch: ${{ env.CI_BRANCH }}
-          secret: ${{ secrets.GITHUB_TOKEN }}
-
   build-publish-galactic-modulo-control:
     needs: build-publish-galactic-modulo
     runs-on: ubuntu-latest
@@ -277,5 +242,39 @@ jobs:
           workspace: ros2-modulo-control
           base_tag: galactic
           dockerfile_extension: .galactic
+          ci_branch: ${{ env.CI_BRANCH }}
+          secret: ${{ secrets.GITHUB_TOKEN }}
+
+  build-publish-humble-modulo-control-devel:
+    needs: build-publish-humble-modulo-devel
+    runs-on: ubuntu-latest
+    name: Build and publish development ROS2 humble workspace image with modulo and ros2 control installed
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build and Push
+        uses: ./.github/actions/build-push-multi-arch
+        with:
+          workspace: ros2-modulo-control
+          base_tag: humble-devel
+          dockerfile_extension: .humble
+          ci_branch: ${{ env.CI_BRANCH }}
+          secret: ${{ secrets.GITHUB_TOKEN }}
+
+  build-publish-humble-modulo-control:
+    needs: build-publish-humble-modulo
+    runs-on: ubuntu-latest
+    name: Build and publish ROS2 humble workspace image with modulo and ros2 control installed
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Build and Push
+        uses: ./.github/actions/build-push-multi-arch
+        with:
+          workspace: ros2-modulo-control
+          base_tag: humble
+          dockerfile_extension: .humble
           ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check-upstream-devel.yml
+++ b/.github/workflows/check-upstream-devel.yml
@@ -17,8 +17,6 @@ jobs:
     outputs:
       cl_id: ${{ steps.check_cl.outputs.id }}
       cl_rebuild: ${{ steps.check_cl.outputs.rebuild }}
-      modulo_develop_id: ${{ steps.check_modulo_develop.outputs.id }}
-      modulo_develop_rebuild: ${{ steps.check_modulo_develop.outputs.rebuild }}
       modulo_humble_id: ${{ steps.check_modulo_humble.outputs.id }}
       modulo_humble_rebuild: ${{ steps.check_modulo_humble.outputs.rebuild }}
     steps:
@@ -54,83 +52,6 @@ jobs:
             echo "::set-output name=rebuild::true"
             echo "::set-output name=id::${NEW_HASH}"
           fi
-
-      - name: Check latest hash on modulo humble branch
-        id: check_modulo_humble
-        run: |
-          NEW_HASH=$(git ls-remote https://github.com/epfl-lasa/modulo.git humble | awk '{ print $1 }')
-          OLD_HASH=$(cat ./modulo-humble-hash || echo '')
-          if [ "${NEW_HASH}" = "${OLD_HASH}" ]; then
-            echo "Modulo doesn't have new commits."
-            echo "::set-output name=rebuild::false"
-          else
-            echo "Modulo has new commits, rebuilding image now..."
-            echo "::set-output name=rebuild::true"
-            echo "::set-output name=id::${NEW_HASH}"
-          fi
-
-  rebuild-cl-galactic-image:
-    needs: check-hash
-    runs-on: ubuntu-latest
-    name: Rebuild ros2-control-libraries galactic-devel image
-    steps:
-      - name: Checkout repository
-        if: ${{ needs.check-hash.outputs.cl_rebuild == 'true' }}
-        uses: actions/checkout@v2
-
-      - name: Build new ros2-control-libraries galactic image
-        if: ${{ needs.check-hash.outputs.cl_rebuild == 'true' }}
-        uses: ./.github/actions/build-push
-        with:
-          workspace: ros2-control-libraries
-          base_tag: galactic
-          cl_branch: develop
-          output_tag: galactic-devel-nightly
-          ci_branch: ${{ env.CI_BRANCH }}
-          secret: ${{ secrets.GITHUB_TOKEN }}
-
-  rebuild-modulo-galactic-image:
-    needs: [check-hash, rebuild-cl-galactic-image]
-    runs-on: ubuntu-latest
-    name: Rebuild ros2-modulo galactic-devel image
-    if: needs.check-hash.outputs.cl_rebuild == 'true' || needs.check-hash.outputs.modulo_develop_rebuild == 'true'
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Build new ros2-modulo galactic-devel image
-        uses: ./.github/actions/build-push
-        with:
-          workspace: ros2-modulo
-          base_tag: galactic-devel-nightly
-          modulo_branch: develop
-          ci_branch: ${{ env.CI_BRANCH }}
-          secret: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Write hash to file and push to ci branch
-        if: ${{ needs.check-hash.outputs.modulo_develop_rebuild == 'true' }}
-        uses: ./.github/actions/write-hash
-        with:
-          hash: ${{ needs.check-hash.outputs.modulo_develop_id }}
-          file: './modulo-develop-hash'
-          ci_branch: ${{ env.CI_BRANCH }}
-
-  rebuild-modulo-control-galactic-image:
-    needs: [ rebuild-modulo-galactic-image ]
-    runs-on: ubuntu-latest
-    name: Rebuild ros2-modulo-control galactic-devel image
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v2
-
-      - name: Build new ros2-modulo-control galactic-devel image
-        uses: ./.github/actions/build-push
-        with:
-          workspace: ros2-modulo-control
-          base_tag: galactic-devel-nightly
-          dockerfile_extension: .galactic
-          ci_branch: ${{ env.CI_BRANCH }}
-          secret: ${{ secrets.GITHUB_TOKEN }}
 
   rebuild-cl-humble-image:
     needs: check-hash
@@ -196,7 +117,7 @@ jobs:
           secret: ${{ secrets.GITHUB_TOKEN }}
 
   write-cl-hash:
-    needs: [ check-hash, rebuild-cl-galactic-image, rebuild-cl-humble-image ]
+    needs: [ check-hash, rebuild-cl-humble-image ]
     runs-on: ubuntu-latest
     name: Write the control libraries hash to file
     if: needs.check-hash.outputs.cl_rebuild == 'true'

--- a/.github/workflows/check-upstream-main.yml
+++ b/.github/workflows/check-upstream-main.yml
@@ -53,22 +53,21 @@ jobs:
             echo "::set-output name=id::${NEW_HASH}"
           fi
 
-  rebuild-cl-galactic-image:
+  rebuild-cl-humble-image:
     needs: check-hash
     runs-on: ubuntu-latest
-    name: Rebuild ros2-control-libraries galactic image
+    name: Rebuild ros2-control-libraries humble image
     steps:
       - name: Checkout repository
         if: ${{ needs.check-hash.outputs.cl_rebuild == 'true' }}
         uses: actions/checkout@v2
 
-      - name: Build new ros2-control-libraries galactic image
+      - name: Build new ros2-control-libraries humble image
         if: ${{ needs.check-hash.outputs.cl_rebuild == 'true' }}
         uses: ./.github/actions/build-push-multi-arch
         with:
           workspace: ros2-control-libraries
-          base_tag: galactic
-          output_tag: galactic
+          base_tag: humble
           cl_branch: main
           ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
@@ -81,20 +80,20 @@ jobs:
           file: './control-libraries-main-hash'
           ci_branch: ${{ env.CI_BRANCH }}
 
-  rebuild-modulo-galactic-image:
-    needs: [check-hash, rebuild-cl-galactic-image]
+  rebuild-modulo-humble-image:
+    needs: [check-hash, rebuild-cl-humble-image]
     runs-on: ubuntu-latest
-    name: Rebuild ros2-modulo galactic image
+    name: Rebuild ros2-modulo humble image
     if: needs.check-hash.outputs.cl_rebuild == 'true' || needs.check-hash.outputs.modulo_rebuild == 'true'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Build new ros2-modulo galactic image
+      - name: Build new ros2-modulo humble image
         uses: ./.github/actions/build-push-multi-arch
         with:
           workspace: ros2-modulo
-          base_tag: galactic
+          base_tag: humble
           modulo_branch: main
           ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
@@ -107,19 +106,19 @@ jobs:
           file: './modulo-main-hash'
           ci_branch: ${{ env.CI_BRANCH }}
 
-  rebuild-modulo-control-galactic-image:
-    needs: [ rebuild-modulo-galactic-image ]
+  rebuild-modulo-control-humble-image:
+    needs: [ rebuild-modulo-humble-image ]
     runs-on: ubuntu-latest
-    name: Rebuild ros2-modulo-control galactic image
+    name: Rebuild ros2-modulo-control humble image
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
 
-      - name: Build new ros2-modulo-control galactic image
+      - name: Build new ros2-modulo-control humble image
         uses: ./.github/actions/build-push-multi-arch
         with:
           workspace: ros2-modulo-control
-          base_tag: galactic
-          dockerfile_extension: .galactic
+          base_tag: humble
+          dockerfile_extension: .humble
           ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/manual-dispatch.yml
+++ b/.github/workflows/manual-dispatch.yml
@@ -22,7 +22,7 @@ on:
       base_tag:
         description: 'The tag of the base image to use'
         required: false
-        default: 'galactic'
+        default: 'humble'
       cl_branch:
         description: 'The branch of control libraries'
         required: false

--- a/ros2_control_libraries/Dockerfile
+++ b/ros2_control_libraries/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-ws
-ARG BASE_TAG=galactic
+ARG BASE_TAG=humble
 ARG UBUNTU_VERSION=focal-fossa
 FROM ${BASE_IMAGE}:${BASE_TAG} as jammy-jellyfish
 

--- a/ros2_control_libraries/build.sh
+++ b/ros2_control_libraries/build.sh
@@ -4,7 +4,7 @@ IMAGE_NAME=aica-technology/ros2-control-libraries
 
 LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros2-ws
-BASE_TAG=galactic
+BASE_TAG=humble
 OUTPUT_TAG=""
 CL_BRANCH=main
 

--- a/ros2_modulo/Dockerfile
+++ b/ros2_modulo/Dockerfile
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-control-libraries
-ARG BASE_TAG=galactic
+ARG BASE_TAG=humble
 FROM ${BASE_IMAGE}:${BASE_TAG}
 
 ARG MODULO_BRANCH=main

--- a/ros2_modulo/build.sh
+++ b/ros2_modulo/build.sh
@@ -4,7 +4,7 @@ IMAGE_NAME=aica-technology/ros2-modulo
 
 LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros2-control-libraries
-BASE_TAG=galactic
+BASE_TAG=humble
 OUTPUT_TAG=""
 MODULO_BRANCH=main
 

--- a/ros2_modulo_control/Dockerfile.galactic
+++ b/ros2_modulo_control/Dockerfile.galactic
@@ -1,5 +1,5 @@
 ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-modulo
-ARG BASE_TAG=galactic
+ARG BASE_TAG=humble
 FROM ${BASE_IMAGE}:${BASE_TAG} as ros2-control-sources
 USER ${USER}
 

--- a/ros2_modulo_control/build.sh
+++ b/ros2_modulo_control/build.sh
@@ -4,7 +4,7 @@ IMAGE_NAME=aica-technology/ros2-modulo-control
 
 LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros2-modulo
-BASE_TAG=galactic
+BASE_TAG=humble
 OUTPUT_TAG=""
 
 BUILD_FLAGS=()

--- a/ros2_ws/Dockerfile
+++ b/ros2_ws/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_TAG=galactic
+ARG BASE_TAG=humble
 FROM ros:${BASE_TAG} as base-dependencies
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONWARNINGS=ignore:::setuptools.command.install,ignore:::setuptools.command.easy_install,ignore:::pkg_resources

--- a/ros2_ws/build.sh
+++ b/ros2_ws/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 IMAGE_NAME=aica-technology/ros2-ws
-BASE_TAG=galactic
+BASE_TAG=humble
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 if [[ ! -f "${SCRIPT_DIR}"/config/sshd_entrypoint.sh ]]; then

--- a/scripts/src/interactive.sh
+++ b/scripts/src/interactive.sh
@@ -22,8 +22,8 @@ Options:
                            the image name, replacing all
                            '/' and ':' with '-' and appending
                            '-runtime'. For example, the image
-                           aica-technology/ros2-ws:galactic would yield
-                           aica-technology-ros2-ws-galactic-runtime
+                           aica-technology/ros2-ws:humble would yield
+                           aica-technology-ros2-ws-humble-runtime
 
   -c, --command <cmd>      Pass a command to execute in the container.
                            (optional, default: ${COMMAND})

--- a/scripts/src/server.sh
+++ b/scripts/src/server.sh
@@ -42,8 +42,8 @@ Options:
                            the image name, replacing all
                            '/' and ':' with '-' and appending
                            '-ssh'. For example, the image
-                           aica-technology/ros2-ws:galactic would yield
-                           aica-technology-ros2-ws-galactic-ssh
+                           aica-technology/ros2-ws:humble would yield
+                           aica-technology-ros2-ws-humble-ssh
 
   -u, --user <user>        Specify the name of the remote user.
                            (default: ${USERNAME})


### PR DESCRIPTION
Okay so this is kinda the 'release' of humble. We replace the galacitc-devel image with a humble-devel image. This means:
- Galactic image with main branch of control libraries, galactic branch of modulo (which is equivalent to v2.1.1)
- Humble image with main branch of control libraries, main branch of modulo
- Humble-devel image with main branch of control libraries, humble branch of modulo (TODO!! this shall be changed to develop once we merged humble into develop on modulo)

I'm currently running this here: https://github.com/domire8/docker-images/actions/runs/3344142806