### PR TITLE
Copy control libraries licenses to AICA images

### DIFF
--- a/ros2_control_libraries/Dockerfile
+++ b/ros2_control_libraries/Dockerfile
@@ -3,16 +3,20 @@ ARG BASE_TAG=humble
 ARG UBUNTU_VERSION=focal-fossa
 FROM ${BASE_IMAGE}:${BASE_TAG} as jammy-jellyfish
 
-# install development dependencies
+# install development dependencies and copy licenses
 COPY --from=ghcr.io/epfl-lasa/control-libraries/development-dependencies:22.04 /usr/local /tmp/local
 RUN sudo cp -R /tmp/local/* /usr/local && sudo rm -r /tmp/local
+COPY --from=ghcr.io/epfl-lasa/control-libraries/development-dependencies:22.04 \
+  /usr/share/doc/control-libraries/licenses /usr/share/doc/control-libraries/licenses
 
 
 FROM ${BASE_IMAGE}:${BASE_TAG} as focal-fossa
 
-# install development dependencies
+# install development dependencies and copy licenses
 COPY --from=ghcr.io/epfl-lasa/control-libraries/development-dependencies:20.04 /usr/local /tmp/local
 RUN sudo cp -R /tmp/local/* /usr/local && sudo rm -r /tmp/local
+COPY --from=ghcr.io/epfl-lasa/control-libraries/development-dependencies:20.04 \
+  /usr/share/doc/control-libraries/licenses /usr/share/doc/control-libraries/licenses
 
 
 FROM ${UBUNTU_VERSION}


### PR DESCRIPTION
Now that we have this sorted out, I think we should also copy the licenses from the control libraries image.

Another option would be to include the "installing" of the licences with the install script but that would take some time again until its on main branch of control libraries
@eeberhard 