### PR TITLE
Fix the lookup of the image hashes

### DIFF
--- a/.github/actions/build-push-multi-arch/action.yml
+++ b/.github/actions/build-push-multi-arch/action.yml
@@ -104,6 +104,8 @@ runs:
           --build-arg CL_BRANCH=${{ inputs.cl_branch }} \
           --build-arg MODULO_BRANCH=${{ inputs.modulo_branch }} \
           ${WORKSPACE_PATH}
+        SHA=$(docker buildx imagetools inspect ghcr.io/${{ github.repository_owner }}/${IMAGE_NAME} | grep Digest)
+        echo "SHA=${SHA##*sha256:}" >> $GITHUB_ENV
       shell: bash
 
     - name: Write new image hash to file
@@ -111,10 +113,8 @@ runs:
       run: |
         git config user.name github-actions
         git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-        git fetch origin ${{ inputs.ci_branch }} && git checkout ${{ inputs.ci_branch }} && git reset --hard HEAD && git rebase origin/main
-        docker pull ghcr.io/${{ github.repository_owner }}/${IMAGE_NAME})
-        SHA=$(docker images --no-trunc --quiet ghcr.io/${{ github.repository_owner }}/${IMAGE_NAME})
-        echo ${SHA} > ./${{ env.WORKSPACE_PATH }}/${{ env.OUTPUT_TAG }}-hash
+        git reset --hard HEAD && git fetch origin ${{ inputs.ci_branch }} && git checkout ${{ inputs.ci_branch }} && git rebase origin/main
+        echo ${{ env.SHA }} > ./${{ env.WORKSPACE_PATH }}/${{ env.OUTPUT_TAG }}-hash
         git add ./${{ env.WORKSPACE_PATH }}/${{ env.OUTPUT_TAG }}-hash
         git commit -m "Update ${{ env.IMAGE_NAME }} image hash" && git push -f
       shell: bash

--- a/.github/actions/build-push-multi-arch/action.yml
+++ b/.github/actions/build-push-multi-arch/action.yml
@@ -112,6 +112,7 @@ runs:
         git config user.name github-actions
         git config user.email 41898282+github-actions[bot]@users.noreply.github.com
         git fetch origin ${{ inputs.ci_branch }} && git checkout ${{ inputs.ci_branch }} && git reset --hard HEAD && git rebase origin/main
+        docker pull ghcr.io/${{ github.repository_owner }}/${IMAGE_NAME})
         SHA=$(docker images --no-trunc --quiet ghcr.io/${{ github.repository_owner }}/${IMAGE_NAME})
         echo ${SHA} > ./${{ env.WORKSPACE_PATH }}/${{ env.OUTPUT_TAG }}-hash
         git add ./${{ env.WORKSPACE_PATH }}/${{ env.OUTPUT_TAG }}-hash

--- a/.github/actions/build-push-multi-arch/action.yml
+++ b/.github/actions/build-push-multi-arch/action.yml
@@ -112,7 +112,7 @@ runs:
         git config user.name github-actions
         git config user.email 41898282+github-actions[bot]@users.noreply.github.com
         git fetch origin ${{ inputs.ci_branch }} && git checkout ${{ inputs.ci_branch }} && git reset --hard HEAD && git rebase origin/main
-        SHA=$(docker images --no-trunc --quiet ${IMAGE_NAME})
+        SHA=$(docker images --no-trunc --quiet ghcr.io/${{ github.repository_owner }}/${IMAGE_NAME})
         echo ${SHA} > ./${{ env.WORKSPACE_PATH }}/${{ env.OUTPUT_TAG }}-hash
         git add ./${{ env.WORKSPACE_PATH }}/${{ env.OUTPUT_TAG }}-hash
         git commit -m "Update ${{ env.IMAGE_NAME }} image hash" && git push -f

--- a/.github/actions/build-push/action.yml
+++ b/.github/actions/build-push/action.yml
@@ -89,6 +89,8 @@ runs:
           --build-arg CL_BRANCH=${{ inputs.cl_branch }} \
           --build-arg MODULO_BRANCH=${{ inputs.modulo_branch }} \
           --tag ${IMAGE_NAME}
+        SHA=$(docker images --no-trunc --quiet ${IMAGE_NAME})
+        echo "SHA=${SHA}" >> $GITHUB_ENV
       shell: bash
 
     - name: Login to GitHub Container Registry
@@ -107,9 +109,8 @@ runs:
       run: |
         git config user.name github-actions
         git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-        git fetch origin ${{ inputs.ci_branch }} && git checkout ${{ inputs.ci_branch }} && git reset --hard HEAD && git rebase origin/main
-        SHA=$(docker images --no-trunc --quiet ${IMAGE_NAME})
-        echo ${SHA} > ./${{ env.WORKSPACE_PATH }}/${{ env.OUTPUT_TAG }}-hash
+        git reset --hard HEAD && git fetch origin ${{ inputs.ci_branch }} && git checkout ${{ inputs.ci_branch }} && git rebase origin/main
+        echo ${{ env.SHA }} > ./${{ env.WORKSPACE_PATH }}/${{ env.OUTPUT_TAG }}-hash
         git add ./${{ env.WORKSPACE_PATH }}/${{ env.OUTPUT_TAG }}-hash
         git commit -m "Update ${{ env.IMAGE_NAME }} image hash" && git push -f
       shell: bash

--- a/.github/actions/write-hash/action.yml
+++ b/.github/actions/write-hash/action.yml
@@ -25,7 +25,7 @@ runs:
       run: |
         git config user.name github-actions
         git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-        git fetch origin ${{ inputs.ci_branch }} && git checkout ${{ inputs.ci_branch }} && git rebase origin/main
+        git reset --hard HEAD && git fetch origin ${{ inputs.ci_branch }} && git checkout ${{ inputs.ci_branch }} && git rebase origin/main
         echo ${{ inputs.hash }} > ${{ inputs.file }}
         git add ${{ inputs.file }}
         git commit -m "Update hash in ${{ inputs.file }}" && git push -f


### PR DESCRIPTION
Right before the release of component SDK, I realized that the CI has another flaw. Since we started using `docker buildx build`, the hash of the image was never correctly retrieved and saved to file anymore. We need to use `docker buildx imagetools inspect` to get the hash of those multi arch files.

The changes are currently tested on my fork: https://github.com/domire8/docker-images/actions/runs/3428680106