### PR TITLE
Reduce number of layers

### DIFF
--- a/ros2_control_libraries/Dockerfile
+++ b/ros2_control_libraries/Dockerfile
@@ -19,7 +19,7 @@ COPY --from=ghcr.io/epfl-lasa/control-libraries/development-dependencies:20.04 \
   /usr/share/doc/control-libraries/licenses /usr/share/doc/control-libraries/licenses
 
 
-FROM ${UBUNTU_VERSION}
+FROM ${UBUNTU_VERSION} as control-libraries-build
 WORKDIR ${HOME}
 
 RUN sudo ldconfig
@@ -38,3 +38,6 @@ RUN sudo pip3 install ./control-libraries/python
 RUN sudo rm -rf ./control-libraries
 
 RUN sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
+
+FROM ${BASE_IMAGE}:${BASE_TAG} as final
+COPY --from=control-libraries-build /usr /usr

--- a/ros2_control_libraries/Dockerfile
+++ b/ros2_control_libraries/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-ws
 ARG BASE_TAG=humble
-ARG UBUNTU_VERSION=focal-fossa
+ARG UBUNTU_VERSION=jammy-jellyfish
 FROM ${BASE_IMAGE}:${BASE_TAG} as jammy-jellyfish
 
 # install development dependencies and copy licenses

--- a/ros2_control_libraries/Dockerfile
+++ b/ros2_control_libraries/Dockerfile
@@ -40,4 +40,5 @@ RUN sudo rm -rf ./control-libraries
 RUN sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
 
 FROM ${BASE_IMAGE}:${BASE_TAG} as final
-COPY --from=control-libraries-build /usr /usr
+RUN sudo rm -rf /usr/include/eigen3
+COPY --from=control-libraries-build /usr/ /usr/

--- a/ros2_control_libraries/Dockerfile
+++ b/ros2_control_libraries/Dockerfile
@@ -35,9 +35,9 @@ RUN sudo ./control-libraries/protocol/install.sh -y
 
 # install python bindings
 RUN sudo pip3 install ./control-libraries/python
-RUN sudo rm -rf ./control-libraries
 
-RUN sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
+# clean image
+RUN sudo rm -rf ./control-libraries && sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
 
 FROM ${BASE_IMAGE}:${BASE_TAG} as final
 RUN sudo rm -rf /usr/include/eigen3

--- a/ros2_modulo/Dockerfile
+++ b/ros2_modulo/Dockerfile
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-control-libraries
 ARG BASE_TAG=humble
-FROM ${BASE_IMAGE}:${BASE_TAG}
+FROM ${BASE_IMAGE}:${BASE_TAG} as modulo-build
 
 ARG MODULO_BRANCH=main
 WORKDIR /tmp
@@ -13,3 +13,6 @@ WORKDIR ${ROS2_WORKSPACE}
 RUN /bin/bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash; colcon build"
 
 RUN sudo rm -rf /tmp/*
+
+FROM ${BASE_IMAGE}:${BASE_TAG} as final
+COPY --from=modulo-build ${ROS2_WORKSPACE} ${ROS2_WORKSPACE}

--- a/ros2_modulo_control/Dockerfile.galactic
+++ b/ros2_modulo_control/Dockerfile.galactic
@@ -1,7 +1,6 @@
 ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-modulo
 ARG BASE_TAG=humble
 FROM ${BASE_IMAGE}:${BASE_TAG} as ros2-control-build
-USER ${USER}
 
 RUN mkdir -p ${ROS2_WORKSPACE}/src/ros2_control
 WORKDIR ${ROS2_WORKSPACE}/src/ros2_control
@@ -17,6 +16,7 @@ RUN git clone -b galactic --depth 1 https://github.com/ros2/rcl_interfaces.git
 RUN git clone -b galactic --depth 1 https://github.com/ros2/test_interface_files.git
 RUN git clone -b ros2 --depth 1 https://github.com/ros/angles.git
 
+WORKDIR ${ROS2_WORKSPACE}
 RUN /bin/bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash; colcon build"
 
 

--- a/ros2_modulo_control/Dockerfile.galactic
+++ b/ros2_modulo_control/Dockerfile.galactic
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-modulo
 ARG BASE_TAG=humble
-FROM ${BASE_IMAGE}:${BASE_TAG} as ros2-control-sources
+FROM ${BASE_IMAGE}:${BASE_TAG} as ros2-control-build
 USER ${USER}
 
 RUN mkdir -p ${ROS2_WORKSPACE}/src/ros2_control
@@ -17,8 +17,8 @@ RUN git clone -b galactic --depth 1 https://github.com/ros2/rcl_interfaces.git
 RUN git clone -b galactic --depth 1 https://github.com/ros2/test_interface_files.git
 RUN git clone -b ros2 --depth 1 https://github.com/ros/angles.git
 
-
-FROM ros2-control-sources as final
-ENV ROS2_WORKSPACE /home/${USER}/ros2_ws
-WORKDIR ${ROS2_WORKSPACE}
 RUN /bin/bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash; colcon build"
+
+
+FROM ${BASE_IMAGE}:${BASE_TAG} as final
+COPY --from=ros2-control-build ${ROS2_WORKSPACE} ${ROS2_WORKSPACE}

--- a/ros2_modulo_control/Dockerfile.humble
+++ b/ros2_modulo_control/Dockerfile.humble
@@ -1,7 +1,6 @@
 ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-modulo
 ARG BASE_TAG=humble
 FROM ${BASE_IMAGE}:${BASE_TAG} as ros2-control-build
-USER ${USER}
 
 RUN mkdir -p ${ROS2_WORKSPACE}/src/ros2_control
 WORKDIR ${ROS2_WORKSPACE}/src/ros2_control
@@ -18,6 +17,7 @@ RUN git clone -b humble --depth 1 https://github.com/ros2/test_interface_files.g
 RUN git clone -b ros2 --depth 1 https://github.com/ros/angles.git
 RUN git clone -b ros2 --depth 1 https://github.com/ros-drivers/ackermann_msgs.git
 
+WORKDIR ${ROS2_WORKSPACE}
 RUN /bin/bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash; colcon build"
 
 

--- a/ros2_modulo_control/Dockerfile.humble
+++ b/ros2_modulo_control/Dockerfile.humble
@@ -1,6 +1,6 @@
 ARG BASE_IMAGE=ghcr.io/aica-technology/ros2-modulo
 ARG BASE_TAG=humble
-FROM ${BASE_IMAGE}:${BASE_TAG} as ros2-control-sources
+FROM ${BASE_IMAGE}:${BASE_TAG} as ros2-control-build
 USER ${USER}
 
 RUN mkdir -p ${ROS2_WORKSPACE}/src/ros2_control
@@ -18,8 +18,8 @@ RUN git clone -b humble --depth 1 https://github.com/ros2/test_interface_files.g
 RUN git clone -b ros2 --depth 1 https://github.com/ros/angles.git
 RUN git clone -b ros2 --depth 1 https://github.com/ros-drivers/ackermann_msgs.git
 
-
-FROM ros2-control-sources as final
-ENV ROS2_WORKSPACE /home/${USER}/ros2_ws
-WORKDIR ${ROS2_WORKSPACE}
 RUN /bin/bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash; colcon build"
+
+
+FROM ${BASE_IMAGE}:${BASE_TAG} as final
+COPY --from=ros2-control-build ${ROS2_WORKSPACE} ${ROS2_WORKSPACE}

--- a/ros2_ws/Dockerfile
+++ b/ros2_ws/Dockerfile
@@ -88,7 +88,7 @@ RUN mkdir /root/.ssh/ && ssh-keyscan github.com | tee -a /root/.ssh/known_hosts
 
 # prepend the environment sourcing to bashrc (appending will fail for non-interactive sessions)
 RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash; \
-  source ${ROS2_WORKSPACE}/install/setup.bash" | cat - ${HOME}/.bashrc > tmp && mv tmp ${HOME}/.bashrc
+source ${ROS2_WORKSPACE}/install/setup.bash" | cat - ${HOME}/.bashrc > tmp && mv tmp ${HOME}/.bashrc
 RUN echo "session required pam_limits.so" | tee --append /etc/pam.d/common-session > /dev/null
 
 # enable colorized output from ros logging

--- a/ros2_ws/Dockerfile
+++ b/ros2_ws/Dockerfile
@@ -1,14 +1,22 @@
 ARG BASE_TAG=humble
-FROM ros:${BASE_TAG} as base-dependencies
+FROM ros:${BASE_TAG} as environment-variables
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONWARNINGS=ignore:::setuptools.command.install,ignore:::setuptools.command.easy_install,ignore:::pkg_resources
+ENV PIP_NO_CACHE_DIR 1
+ENV USER ros2
+ENV HOME /home/${USER}
+ENV ROS2_WORKSPACE /home/${USER}/ros2_ws
+ENV COLCON_HOME ${HOME}/.colcon
+ENV COLCON_DEFAULTS_FILE ${COLCON_HOME}/defaults.yaml
+ENV COLCON_WORKSPACE=${ROS2_WORKSPACE}
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+
+
+FROM environment-variables as base-dependencies
 
 # disable suggested and recommended install
 RUN apt-config dump | grep -we Recommends -e Suggests | sed s/1/0/ \
   | sudo tee /etc/apt/apt.conf.d/999norecommend
-
-# disable pip caching
-ENV PIP_NO_CACHE_DIR 1
 
 # install base dependencies
 RUN apt-get update && apt-get install --no-install-recommends -y \
@@ -46,9 +54,6 @@ RUN ( \
 
 
 FROM base-dependencies as base-workspace
-ENV USER ros2
-ENV HOME /home/${USER}
-ENV ROS2_WORKSPACE /home/${USER}/ros2_ws
 
 # create amd configure a new user
 ARG UID=1000
@@ -67,20 +72,14 @@ RUN chmod 744 /sshd_entrypoint.sh
 # configure colcon defaults and utilities
 USER ${USER}
 WORKDIR ${HOME}
-ENV COLCON_HOME ${HOME}/.colcon
 RUN mkdir -p ${COLCON_HOME}
 COPY --chown=${USER}:${USER} ./config/colcon ${COLCON_HOME}
 RUN /bin/bash ${COLCON_HOME}/setup.sh
-ENV COLCON_DEFAULTS_FILE ${COLCON_HOME}/defaults.yaml
-
-# set the default colcon workspace path
-ENV COLCON_WORKSPACE=${ROS2_WORKSPACE}
 
 # build ROS workspace
 RUN mkdir -p ${ROS2_WORKSPACE}/src
 WORKDIR ${ROS2_WORKSPACE}
 RUN rosdep update
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 RUN /bin/bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash; colcon build --symlink-install"
 
 # create the credentials to be able to pull private repos using ssh
@@ -89,15 +88,16 @@ RUN mkdir /root/.ssh/ && ssh-keyscan github.com | tee -a /root/.ssh/known_hosts
 
 # prepend the environment sourcing to bashrc (appending will fail for non-interactive sessions)
 RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash; \
-source ${ROS2_WORKSPACE}/install/setup.bash" | cat - ${HOME}/.bashrc > tmp && mv tmp ${HOME}/.bashrc
+  source ${ROS2_WORKSPACE}/install/setup.bash" | cat - ${HOME}/.bashrc > tmp && mv tmp ${HOME}/.bashrc
 RUN echo "session required pam_limits.so" | tee --append /etc/pam.d/common-session > /dev/null
 
 # enable colorized output from ros logging
 RUN echo "export RCUTILS_COLORIZED_OUTPUT=1" >> ${HOME}/.bashrc
 
+
+FROM environment-variables as final
+COPY --from=base-workspace / /
+
 # start as ROS user
 USER ${USER}
 WORKDIR ${ROS2_WORKSPACE}
-
-# Clean image
-RUN sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*

--- a/ros2_ws/Dockerfile
+++ b/ros2_ws/Dockerfile
@@ -55,7 +55,7 @@ RUN ( \
 
 FROM base-dependencies as base-workspace
 
-# create amd configure a new user
+# create and configure a new user
 ARG UID=1000
 ARG GID=1000
 RUN addgroup --gid ${GID} ${USER}

--- a/ros_control_libraries/Dockerfile
+++ b/ros_control_libraries/Dockerfile
@@ -1,27 +1,34 @@
 ARG BASE_IMAGE=ghcr.io/aica-technology/ros-ws
 ARG BASE_TAG=noetic
-FROM ${BASE_IMAGE}:${BASE_TAG}
+FROM ${BASE_IMAGE}:${BASE_TAG} as focal-fossa
 
-# install google dependencies
-COPY --from=ghcr.io/epfl-lasa/control-libraries/proto-dependencies:latest /usr/local/include/google /usr/local/include/google
-COPY --from=ghcr.io/epfl-lasa/control-libraries/proto-dependencies:latest /usr/local/lib/libproto* /usr/local/lib/
-COPY --from=ghcr.io/epfl-lasa/control-libraries/proto-dependencies:latest /usr/local/bin/protoc /usr/local/bin
+# install development dependencies and copy licenses
+COPY --from=ghcr.io/epfl-lasa/control-libraries/development-dependencies:20.04 /usr/local /tmp/local
+RUN sudo cp -R /tmp/local/* /usr/local && sudo rm -r /tmp/local
+COPY --from=ghcr.io/epfl-lasa/control-libraries/development-dependencies:20.04 \
+  /usr/share/doc/control-libraries/licenses /usr/share/doc/control-libraries/licenses
+
+
+FROM focal-fossa as control-libraries-build
+WORKDIR ${HOME}
+
 RUN sudo ldconfig
 
 ARG CL_BRANCH=main
-WORKDIR ${HOME}
 RUN git clone -b ${CL_BRANCH} --depth 1 https://github.com/epfl-lasa/control-libraries.git
 
 # install source
 RUN sudo ./control-libraries/source/install.sh -y
-ENV CMAKE_PREFIX_PATH=/opt/openrobots:${CMAKE_PREFIX_PATH}
+
 # install protocol
 RUN sudo ./control-libraries/protocol/install.sh -y
+
 # install python bindings
 RUN sudo pip3 install ./control-libraries/python
-RUN sudo rm -rf ./control-libraries
 
-RUN sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
+# clean image
+RUN sudo rm -rf ./control-libraries && sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*
 
-# Restore the key for robotpkg
-RUN sudo curl http://robotpkg.openrobots.org/packages/debian/robotpkg.key | sudo apt-key add -
+FROM ${BASE_IMAGE}:${BASE_TAG} as final
+RUN sudo rm -rf /usr/include/eigen3
+COPY --from=control-libraries-build /usr/ /usr/

--- a/ros_control_libraries/build.sh
+++ b/ros_control_libraries/build.sh
@@ -5,7 +5,7 @@ IMAGE_NAME=aica-technology/ros-control-libraries
 LOCAL_BASE_IMAGE=false
 BASE_IMAGE=ghcr.io/aica-technology/ros-ws
 BASE_TAG=noetic
-OUTPUT_TAG=noetic
+OUTPUT_TAG=""
 CL_BRANCH=main
 
 BUILD_FLAGS=()
@@ -41,6 +41,11 @@ while [ "$#" -gt 0 ]; do
     ;;
   esac
 done
+
+if [ -z "${OUTPUT_TAG}" ]; then
+  echo "Output tag is empty, using the base tag as output tag."
+  OUTPUT_TAG="${BASE_TAG}"
+fi
 
 if [ "${LOCAL_BASE_IMAGE}" == true ]; then
   BUILD_FLAGS+=(--build-arg BASE_IMAGE=aica-technology/ros-ws)

--- a/ros_ws/Dockerfile
+++ b/ros_ws/Dockerfile
@@ -1,8 +1,21 @@
 ARG BASE_TAG=noetic
-FROM ros:${BASE_TAG} as base-dependencies
+FROM ros:${BASE_TAG} as environment-variables
 ENV DEBIAN_FRONTEND=noninteractive
+ENV PIP_NO_CACHE_DIR 1
+ENV USER ros
+ENV HOME /home/${USER}
+ENV ROS_WORKSPACE /home/${USER}/ros_ws
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 
-RUN apt-get update && apt-get install -y \
+
+FROM environment-variables as base-dependencies
+
+# disable suggested and recommended install
+RUN apt-config dump | grep -we Recommends -e Suggests | sed s/1/0/ \
+  | sudo tee /etc/apt/apt.conf.d/999norecommend
+
+# install base dependencies
+RUN apt-get update && apt-get install --no-install-recommends -y \
   curl \
   featherpad \
   gdb \
@@ -21,18 +34,12 @@ RUN apt-get update && apt-get install -y \
   software-properties-common \
   ssh \
   unzip \
+  wget \
   && rm -rf /var/lib/apt/lists/*
 
 RUN echo "Set disable_coredump false" >> /etc/sudo.conf
 
-# disable suggested and recommended install
-RUN apt-config dump | grep -we Recommends -e Suggests | sed s/1/0/ \
-  | sudo tee /etc/apt/apt.conf.d/999norecommend
-
-# disable pip caching
-ENV PIP_NO_CACHE_DIR=1
-
-# Configure sshd server settings
+# configure sshd server settings
 RUN ( \
     echo 'LogLevel DEBUG2'; \
     echo 'PubkeyAuthentication yes'; \
@@ -55,7 +62,7 @@ RUN usermod -a -G dialout ${USER}
 RUN echo "${USER} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/99_aptget
 RUN chmod 0440 /etc/sudoers.d/99_aptget && chown root:root /etc/sudoers.d/99_aptget
 
-# Configure sshd entrypoint to authorise the new user for ssh access and
+# configure sshd entrypoint to authorise the new user for ssh access and
 # optionally update UID and GID when invoking the container with the entrypoint script
 COPY ./config/sshd_entrypoint.sh /sshd_entrypoint.sh
 RUN chmod 744 /sshd_entrypoint.sh
@@ -65,7 +72,6 @@ USER ${USER}
 RUN mkdir -p ${ROS_WORKSPACE}/src
 WORKDIR ${ROS_WORKSPACE}
 RUN rosdep update
-ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
 RUN /bin/bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash; catkin_make"
 
 # create the credentials to be able to pull private repos using ssh
@@ -77,9 +83,10 @@ RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash; \
 source ${ROS_WORKSPACE}/devel/setup.bash" | cat - ${HOME}/.bashrc > tmp && mv tmp ${HOME}/.bashrc
 RUN echo "session required pam_limits.so" | tee --append /etc/pam.d/common-session > /dev/null
 
+
+FROM environment-variables as final
+COPY --from=base-workspace / /
+
 # start as ROS user
 USER ${USER}
 WORKDIR ${ROS_WORKSPACE}
-
-# Clean image
-RUN sudo apt-get clean && sudo rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
I was also working on the docker images over the weekend @eeberhard :smile: 
Due to the fact that the stash option is deprecated with buildx and will most likely not come back, we need to leverage multi-stage builds to reduce the number of layers in our Dockerfiles. With the proposed changes, I was able to reduce the amount of layers from 66 to 17 in the ros2-modulo-control image. How, you ask?

Use intermediate stages to build the sources and copy only the results (results in one additional layer only, especially easy for modulo and ros2 control, because it's just the ros2 workspace that was changed)

For the workspace and control libraries, it's slightly more complicated..
- For the ros2-ws, I need a layer that defines all the environment variables on the ros:humble image, then I copy the whole filesystem in the last stage.
- For ros2-control-libraries, the install script creates a symbolic link for eigen. Because docker cannot copy and override a real file with a symlink, I need to remove `/usr/include/eigen` from the base image before the copy step.

I'm currently testing this image with the robot and I cannot spot any problems so far