### PR TITLE
Remove galactic from workflows

### DIFF
--- a/.github/actions/build-push-multi-arch/action.yml
+++ b/.github/actions/build-push-multi-arch/action.yml
@@ -102,12 +102,15 @@ runs:
         IMAGE_NAME=${{ env.IMAGE_NAME }}
         DOCKERFILE=${WORKSPACE_PATH}/Dockerfile${{ inputs.dockerfile_extension }}
 
-        if [[ "${BASE_TAG}" == *"galactic"* ]]; then
+        if [[ "${BASE_TAG}" == *"noetic"* ]]; then
           UBUNTU_VERSION=focal-fossa
+        elif [[ "${BASE_TAG}" == *"humble"* ]]; then
+          UBUNTU_VERSION=focal-fossa
+        else
         elif [[ "${BASE_TAG}" == *"humble"* ]]; then
           UBUNTU_VERSION=jammy-jellyfish
         else
-          echo "::error::Invalid base tag. Base tag needs to contain either 'galactic' or 'humble'."
+          echo "::error::Invalid base tag. Base tag needs to contain either 'noetic', 'galactic' or 'humble'."
           exit 1
         fi
 

--- a/.github/actions/build-push-multi-arch/action.yml
+++ b/.github/actions/build-push-multi-arch/action.yml
@@ -104,9 +104,8 @@ runs:
 
         if [[ "${BASE_TAG}" == *"noetic"* ]]; then
           UBUNTU_VERSION=focal-fossa
-        elif [[ "${BASE_TAG}" == *"humble"* ]]; then
+        elif [[ "${BASE_TAG}" == *"galactic"* ]]; then
           UBUNTU_VERSION=focal-fossa
-        else
         elif [[ "${BASE_TAG}" == *"humble"* ]]; then
           UBUNTU_VERSION=jammy-jellyfish
         else

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -25,22 +25,6 @@ jobs:
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
           git checkout -b ${{ env.CI_BRANCH }} origin/main && git push -f -u origin ${{ env.CI_BRANCH }}
 
-  build-publish-galactic-workspace:
-    needs: create-new-ci-branch
-    runs-on: ubuntu-latest
-    name: Build and publish ROS2 galactic workspace image
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Build and Push
-        uses: ./.github/actions/build-push-multi-arch
-        with:
-          workspace: ros2-ws
-          base_tag: galactic
-          ci_branch: ${{ env.CI_BRANCH }}
-          secret: ${{ secrets.GITHUB_TOKEN }}
-
   build-publish-humble-workspace:
     needs: create-new-ci-branch
     runs-on: ubuntu-latest
@@ -54,23 +38,6 @@ jobs:
         with:
           workspace: ros2-ws
           base_tag: humble
-          ci_branch: ${{ env.CI_BRANCH }}
-          secret: ${{ secrets.GITHUB_TOKEN }}
-
-  build-publish-galactic-control-libraries:
-    needs: build-publish-galactic-workspace
-    runs-on: ubuntu-latest
-    name: Build and publish ROS2 galactic workspace image with control libraries installed
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Build and Push
-        uses: ./.github/actions/build-push-multi-arch
-        with:
-          workspace: ros2-control-libraries
-          base_tag: galactic
-          cl_branch: main
           ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
 
@@ -90,14 +57,6 @@ jobs:
           cl_branch: main
           ci_branch: ${{ env.CI_BRANCH }}
           secret: ${{ secrets.GITHUB_TOKEN }}
-
-  write-control-libraries-main-hash:
-    needs: [ build-publish-galactic-control-libraries, build-publish-humble-control-libraries]
-    runs-on: ubuntu-latest
-    name: Write control libraries main hash to file
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
 
       - name: Get control libraries main hash
         run: |
@@ -139,35 +98,6 @@ jobs:
         with:
           hash: ${{ env.CL_DEVELOP_HASH }}
           file: ./control-libraries-develop-hash
-          ci_branch: ${{ env.CI_BRANCH }}
-
-  build-publish-galactic-modulo:
-    needs: build-publish-galactic-control-libraries
-    runs-on: ubuntu-latest
-    name: Build and publish ROS2 galactic workspace image with modulo installed
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Build and Push
-        uses: ./.github/actions/build-push-multi-arch
-        with:
-          workspace: ros2-modulo
-          base_tag: galactic
-          modulo_branch: galactic
-          ci_branch: ${{ env.CI_BRANCH }}
-          secret: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Get modulo galactic hash
-        run: |
-          HASH=$(git ls-remote https://github.com/epfl-lasa/modulo.git galactic | awk '{ print $1 }')
-          echo "MODULO_GALACTIC_HASH=${HASH}" >> $GITHUB_ENV
-
-      - name: Write hash
-        uses: ./.github/actions/write-hash
-        with:
-          hash: ${{ env.MODULO_GALACTIC_HASH }}
-          file: ./modulo-galactic-hash
           ci_branch: ${{ env.CI_BRANCH }}
 
   build-publish-humble-modulo-devel:
@@ -227,23 +157,6 @@ jobs:
           hash: ${{ env.MODULO_MAIN_HASH }}
           file: ./modulo-main-hash
           ci_branch: ${{ env.CI_BRANCH }}
-
-  build-publish-galactic-modulo-control:
-    needs: build-publish-galactic-modulo
-    runs-on: ubuntu-latest
-    name: Build and publish ROS2 galactic workspace image with modulo and ros2 control installed
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v3
-
-      - name: Build and Push
-        uses: ./.github/actions/build-push-multi-arch
-        with:
-          workspace: ros2-modulo-control
-          base_tag: galactic
-          dockerfile_extension: .galactic
-          ci_branch: ${{ env.CI_BRANCH }}
-          secret: ${{ secrets.GITHUB_TOKEN }}
 
   build-publish-humble-modulo-control-devel:
     needs: build-publish-humble-modulo-devel

--- a/ros2_control_libraries/Dockerfile
+++ b/ros2_control_libraries/Dockerfile
@@ -42,3 +42,4 @@ RUN sudo rm -rf ./control-libraries && sudo apt-get clean && sudo rm -rf /var/li
 FROM ${BASE_IMAGE}:${BASE_TAG} as final
 RUN sudo rm -rf /usr/include/eigen3
 COPY --from=control-libraries-build /usr/ /usr/
+RUN sudo ldconfig

--- a/ros_control_libraries/Dockerfile
+++ b/ros_control_libraries/Dockerfile
@@ -32,3 +32,4 @@ RUN sudo rm -rf ./control-libraries && sudo apt-get clean && sudo rm -rf /var/li
 FROM ${BASE_IMAGE}:${BASE_TAG} as final
 RUN sudo rm -rf /usr/include/eigen3
 COPY --from=control-libraries-build /usr/ /usr/
+RUN sudo ldconfig


### PR DESCRIPTION
This PR had very low priority because I didn't mind the galactic builds very much but now, I realized with @Maxime00 that the `sudo ldconfig` is very much necessary at the end of the control libraries images, so this became now the actual reason for this PR.