### PR TITLE
Set UID and GID of local user in interactive container

### DIFF
--- a/common/entrypoint.sh
+++ b/common/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -e
+
+if [ $(id -u) -ne 0 ]; then
+  echo "Fixing UID, this can take a few moments..."
+  eval $( fixuid -q )
+fi
+
+# setup ros2 environment
+source "/opt/ros/$ROS_DISTRO/setup.bash" --
+exec "$@"

--- a/ros2_ws/.gitignore
+++ b/ros2_ws/.gitignore
@@ -1,1 +1,2 @@
 config/sshd_entrypoint.sh
+config/entrypoint.sh

--- a/ros2_ws/Dockerfile
+++ b/ros2_ws/Dockerfile
@@ -69,6 +69,18 @@ RUN chmod 0440 /etc/sudoers.d/99_aptget && chown root:root /etc/sudoers.d/99_apt
 COPY ./config/sshd_entrypoint.sh /sshd_entrypoint.sh
 RUN chmod 744 /sshd_entrypoint.sh
 
+# configure entrypoint to remap UID and GID with 'fixuid' if requested user is not root
+# this helps with permission issues of shared volumes
+ARG TARGETPLATFORM
+COPY ./config/entrypoint.sh /entrypoint.sh
+RUN chmod 745 /entrypoint.sh
+RUN /bin/bash -c 'ARCH=${TARGETPLATFORM/\//-} && \
+    curl -SsL https://github.com/boxboat/fixuid/releases/download/v0.5.1/fixuid-0.5.1-${ARCH}.tar.gz | tar -C /usr/local/bin -xzf -' \
+RUN chown root:root /usr/local/bin/fixuid && \
+    chmod 4755 /usr/local/bin/fixuid && \
+    mkdir -p /etc/fixuid && \
+    printf "user: ${USER}\ngroup: ${USER}\n" > /etc/fixuid/config.yml
+
 # configure colcon defaults and utilities
 USER ${USER}
 WORKDIR ${HOME}

--- a/ros2_ws/Dockerfile
+++ b/ros2_ws/Dockerfile
@@ -106,6 +106,8 @@ RUN echo "session required pam_limits.so" | tee --append /etc/pam.d/common-sessi
 # enable colorized output from ros logging
 RUN echo "export RCUTILS_COLORIZED_OUTPUT=1" >> ${HOME}/.bashrc
 
+COPY ./config/entrypoint.sh /entrypoint.sh
+
 # FIXME(#76): Remove once dependencies are fixed again
 RUN add-apt-repository ppa:kisak/kisak-mesa && apt update && apt upgrade -y && rm -rf /var/lib/apt/lists/*
 
@@ -116,3 +118,5 @@ COPY --from=base-workspace / /
 # start as ROS user
 USER ${USER}
 WORKDIR ${ROS2_WORKSPACE}
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/ros2_ws/build.sh
+++ b/ros2_ws/build.sh
@@ -8,6 +8,10 @@ if [[ ! -f "${SCRIPT_DIR}"/config/sshd_entrypoint.sh ]]; then
   mkdir -p "${SCRIPT_DIR}"/config
   cp "$(dirname "${SCRIPT_DIR}")"/common/sshd_entrypoint.sh "${SCRIPT_DIR}"/config/ || exit 1
 fi
+if [[ ! -f "${SCRIPT_DIR}"/config/entrypoint.sh ]]; then
+  mkdir -p "${SCRIPT_DIR}"/config
+  cp "$(dirname "${SCRIPT_DIR}")"/common/entrypoint.sh "${SCRIPT_DIR}"/config/ || exit 1
+fi
 
 BUILD_FLAGS=()
 while [ "$#" -gt 0 ]; do

--- a/scripts/src/interactive.sh
+++ b/scripts/src/interactive.sh
@@ -108,8 +108,10 @@ if [ -z "${CONTAINER_NAME}" ]; then
   CONTAINER_NAME="${CONTAINER_NAME/:/-}-runtime"
 fi
 
-if [ -n "${USERNAME}" ]; then
-  RUN_FLAGS+=(-u "${USERNAME}")
+if [[ "${USERNAME}" == "root" ]]; then
+  RUN_FLAGS+=(-u "root:root")
+else
+  RUN_FLAGS+=(-u "$(id -u "${USER}")":"$(id -g "${USER}")")
 fi
 
 if [ $GENERATE_HOST_NAME == true ]; then


### PR DESCRIPTION
<!-- AICA Pull Request Template: 10 easy steps for a successful PR!
1. Give the PR a relevant and descriptive title
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
6. Add any supporting resources (screenshots, test results, etc)
7. Help the reviewer by suggestion the method and estimated time to review
8. If applicable, make a checklist of tasks that should be completed before merging
9. If applicable, mention related issues (blocked by / blocks)
10. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->
- #78 

<!-- Required: explain how the PR addresses the parent issue -->
This PR solves the issue by installing the tool [fixuid](https://github.com/boxboat/fixuid) (MIT license) that is invoked in the entrypoint script to change the UID and GID of the docker `ros2` user to the same values as the local user. Unfortunately, this may take up to a minute for the ros2-modulo-control image due to the recursive change of ownership of the home folder (which is why I will add additional steps in the backend Dockerfile, such that we can do this on build and not on run)

## Supporting information
Tested on
- Mac
- Virtual ARM64 ubuntu on mac
- AMD64 ubuntu

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 10 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

<!-- Optional: define a task list that should be completed before merging
## Checklist before merging:
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->