### PR TITLE
Fix aica-docker installation for Mac

### DIFF
--- a/scripts/install-aica-docker.sh
+++ b/scripts/install-aica-docker.sh
@@ -45,8 +45,8 @@ while true; do
   read -r -p "Do you with to install auto completion for aica-docker to '${SHELL_RC_PATH}'? [YES|no]
 >>>" yn
   case $yn in
-    "" | yes) source_completion_script "${SHELL_RC_PATH}"; break;;
-    no) exit;;
-    *) echo "Please answer 'yes' or 'no'.";;
+    "" | yes | YES | y) source_completion_script "${SHELL_RC_PATH}"; break;;
+    no | n) exit;;
+    *) echo "Please answer 'yes/y' or 'no/n'.";;
   esac
 done

--- a/scripts/install-aica-docker.sh
+++ b/scripts/install-aica-docker.sh
@@ -22,11 +22,7 @@ function get_shell_rc_path () {
 function source_completion_script () {
   echo "Writing the auto completion option to $1."
   grep -v /src/aica-docker-completion.sh "$1" > tmpfile && mv tmpfile "$1"
-  if [[ "$OSTYPE" != "darwin"* ]]; then
-    echo "source ${SCRIPT_DIR}/src/aica-docker-completion.sh" >> "$1"
-  else
-    echo "autoload bashcompinit; bashcompinit; source ${SCRIPT_DIR}/src/aica-docker-completion.sh" >> "$1"
-  fi
+  echo "source ${SCRIPT_DIR}/src/aica-docker-completion.sh" >> "$1"
 }
 
 if [[ "$OSTYPE" != "darwin"* ]]; then

--- a/scripts/src/aica-docker-completion.sh
+++ b/scripts/src/aica-docker-completion.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 SCRIPTS=("connect" "interactive" "server")
-CONTAINERS=$(docker ps --format "{{ .Names }}")
-IMAGES=$(docker images --format "{{.Repository}}:{{.Tag}}")
+CONTAINERS=$(docker ps --format "{{ .Names }}" 2> /dev/null)
+IMAGES=$(docker images --format "{{.Repository}}:{{.Tag}}" 2> /dev/null)
 IMAGES=${IMAGES//"<none>:<none>"/}
 
 _aica_docker () {

--- a/scripts/src/aica-docker-completion.sh
+++ b/scripts/src/aica-docker-completion.sh
@@ -12,8 +12,8 @@ _aica_docker () {
   prev="${COMP_WORDS[COMP_CWORD-1]}"
 
   if [[ ${COMP_CWORD} -eq 2 ]]; then
-    CONTAINERS=$(docker ps --format "{{ .Names }}")
-    IMAGES=$(docker images --format "{{.Repository}}:{{.Tag}}")
+    CONTAINERS=$(docker ps --format "{{ .Names }}" 2> /dev/null)
+    IMAGES=$(docker images --format "{{.Repository}}:{{.Tag}}" 2> /dev/null)
     IMAGES=${IMAGES//"<none>:<none>"/}
   fi
 


### PR DESCRIPTION
<!-- AICA Pull Request Template: 10 easy steps for a successful PR!
1. Give the PR a relevant and descriptive title
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
6. Add any supporting resources (screenshots, test results, etc)
7. Help the reviewer by suggestion the method and estimated time to review
8. If applicable, make a checklist of tasks that should be completed before merging
9. If applicable, mention related issues (blocked by / blocks)
10. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: explain how the PR addresses the parent issue -->
This PR addresses the problem with the aica-docker installation on Mac. So far, we added `autoload bashcompinit; bashcompinit` which might not be a known command if you use zsh and should rather be enabled by the user itself on another line of the bashrc file. In other words, if the user didn't enable autocomplete in general yet, aica-docker is not going to change that.

## Supporting information
Would be nice if you could test that @eeberhard 

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 5 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

<!-- Optional: define a task list that should be completed before merging
## Checklist before merging:
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->