### PR TITLE
Fix ownership of bashrc

### DIFF
--- a/ros2_ws/Dockerfile
+++ b/ros2_ws/Dockerfile
@@ -82,17 +82,16 @@ WORKDIR ${ROS2_WORKSPACE}
 RUN rosdep update
 RUN /bin/bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash; colcon build --symlink-install"
 
-# create the credentials to be able to pull private repos using ssh
-USER root
-RUN mkdir /root/.ssh/ && ssh-keyscan github.com | tee -a /root/.ssh/known_hosts
-
 # prepend the environment sourcing to bashrc (appending will fail for non-interactive sessions)
 RUN echo "source /opt/ros/${ROS_DISTRO}/setup.bash; \
 source ${ROS2_WORKSPACE}/install/setup.bash" | cat - ${HOME}/.bashrc > tmp && mv tmp ${HOME}/.bashrc
-RUN echo "session required pam_limits.so" | tee --append /etc/pam.d/common-session > /dev/null
-
 # enable colorized output from ros logging
 RUN echo "export RCUTILS_COLORIZED_OUTPUT=1" >> ${HOME}/.bashrc
+
+# create the credentials to be able to pull private repos using ssh
+USER root
+RUN mkdir /root/.ssh/ && ssh-keyscan github.com | tee -a /root/.ssh/known_hosts
+RUN echo "session required pam_limits.so" | tee --append /etc/pam.d/common-session > /dev/null
 
 # FIXME(#76): Remove once dependencies are fixed again
 RUN add-apt-repository ppa:kisak/kisak-mesa && apt update && apt upgrade -y && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
<!-- AICA Pull Request Template: 10 easy steps for a successful PR!
1. Give the PR a relevant and descriptive title
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
6. Add any supporting resources (screenshots, test results, etc)
7. Help the reviewer by suggestion the method and estimated time to review
8. If applicable, make a checklist of tasks that should be completed before merging
9. If applicable, mention related issues (blocked by / blocks)
10. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

<!-- Required: explain how the PR addresses the parent issue -->
This PR solves the issue of the ownership of `.bashrc` by editing it as `ros2` and not `root` user.
Detected in aica-technology/dynamic-state-engine#103

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 2 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

<!-- Optional: define a task list that should be completed before merging
## Checklist before merging:
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->