### PR TITLE
Fix reusable build push workflow

### DIFF
--- a/.github/workflows/reusable-build-push.yml
+++ b/.github/workflows/reusable-build-push.yml
@@ -157,7 +157,7 @@ jobs:
 
   get-dependency-hash:
     needs: [ write-image-hash ]
-    if: inputs.workspace == 'ros2-control-libraries' || inputs.workspace == 'ros2-modulo'
+    if: inputs.workspace == 'ros2-control-libraries' || inputs.workspace == 'ros2-modulo-control'
     runs-on: ubuntu-latest
     name: Get hash of installed library
     outputs:
@@ -178,7 +178,7 @@ jobs:
             BRANCH=${{ inputs.cl_branch }}
             HASH_FILENAME="./control-libraries-${BRANCH}-hash"
             HASH=$(git ls-remote https://github.com/aica-technology/control-libraries.git ${BRANCH} | awk '{ print $1 }')
-          elif [[ "${{ inputs.workspace }}" == "ros2-modulo" ]]; then
+          elif [[ "${{ inputs.workspace }}" == "ros2-modulo-control" ]]; then
             BRANCH=${{ inputs.modulo_branch }}
             HASH_FILENAME="./modulo-${BRANCH}-hash"
             HASH=$(git ls-remote https://github.com/aica-technology/modulo.git ${BRANCH} | awk '{ print $1 }')


### PR DESCRIPTION
<!-- AICA Pull Request Template: 10 easy steps for a successful PR!
1. Give the PR a relevant and descriptive title
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
6. Add any supporting resources (screenshots, test results, etc)
7. Help the reviewer by suggestion the method and estimated time to review
8. If applicable, make a checklist of tasks that should be completed before merging
9. If applicable, mention related issues (blocked by / blocks)
10. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

<!-- Required: explain how the PR addresses the parent issue -->
I needed to fix two lines in a workflow because the ros2-modulo workspace has been renamed and we now need to write the modulo hash upon build of the ros2-modulo-control image. Apart from that, the reshuffling of the images worked out nicely I believe, the workflows are good and the backend builds and runs fine too.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 1.1 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

<!-- Optional: define a task list that should be completed before merging
## Checklist before merging:
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->