### PR TITLE
fix: define all build args at the top of the Dockerfile

### DIFF
--- a/ros2_ws/Dockerfile
+++ b/ros2_ws/Dockerfile
@@ -1,5 +1,8 @@
 ARG BASE_IMAGE=docker.io/library/ros
 ARG BASE_TAG=iron
+ARG ROS_DISTRO=iron
+ARG VERSION=v0.0.0
+
 FROM ${BASE_IMAGE}:${BASE_TAG} as environment-variables
 ENV DEBIAN_FRONTEND=noninteractive
 ENV PYTHONWARNINGS=ignore:::setuptools.command.install,ignore:::setuptools.command.easy_install,ignore:::pkg_resources
@@ -134,7 +137,6 @@ WORKDIR ${ROS2_WORKSPACE}
 RUN /bin/bash -c "source /opt/ros/${ROS_DISTRO}/setup.bash; colcon build"
 RUN rm -rf ./src
 
-ARG ROS_DISTRO=iron
 FROM ros2-control-${ROS_DISTRO} as ros2-control
 
 FROM environment-variables as final
@@ -145,9 +147,6 @@ USER ${USER}
 WORKDIR ${ROS2_WORKSPACE}
 
 # Metadata
-ARG BASE_IMAGE=docker.io/library/ros
-ARG BASE_TAG=iron
-ARG VERSION=v0.0.0
 LABEL org.opencontainers.image.title="AICA ROS 2 image"
 LABEL org.opencontainers.image.description="AICA base ROS 2 image (includes ros2_control)"
 LABEL org.opencontainers.image.version="${VERSION}"


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

Fix following build failure here:

- https://github.com/aica-technology/docker-images/actions/runs/9061701641/job/24894045916

Build args need to be declared at the top layer, otherwise they might be skipped in intermediate layers and remain undefined. As part of this, I removed the secondary declarations of the build args in the later layer.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 1.1 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [x] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->