### PR TITLE
fix: build args and metadata variables

### DIFF
--- a/ros2_ws/Dockerfile
+++ b/ros2_ws/Dockerfile
@@ -147,9 +147,13 @@ USER ${USER}
 WORKDIR ${ROS2_WORKSPACE}
 
 # Metadata
+ARG BASE_IMAGE=docker.io/library/ros
+ARG BASE_TAG=iron
+ARG ROS_DISTRO=iron
+ARG VERSION=v0.0.0
 LABEL org.opencontainers.image.title="AICA ROS 2 image"
 LABEL org.opencontainers.image.description="AICA base ROS 2 image (includes ros2_control)"
 LABEL org.opencontainers.image.version="${VERSION}"
 LABEL org.opencontainers.image.base.name="${BASE_IMAGE}:${BASE_TAG}"
-LABEL tech.aica.image.metadata='{"type":"base/ws","base":{"name":"${BASE_IMAGE}:${BASE_TAG}","version":"${VERSION}"}}'
+LABEL tech.aica.image.metadata='{"type":"base/ws","base":{"name":"'${BASE_IMAGE}':'${BASE_TAG}'","version":"'${VERSION}'"}}'
 LABEL devcontainer.metadata='[{"containerUser": "ros2"}]'


### PR DESCRIPTION
* Redeclare build args before final metadata layer

* Use single quotes to escape varibales to be replaced in metadata

<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

Thanks @LouisBrunner for the comments on #110. This is what I get for meddling in the docker image setup after you and @domire8 did most of the work 😁

This adds back the declaration of build args in the last layer, and single quotes around the build args in the metadata.

Let's try this a third time.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 2 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [x] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->