### PR TITLE
fix: resolution of generate_compile_commands default output directory

### DIFF
--- a/ros2_ws/config/generate_compile_commands.sh
+++ b/ros2_ws/config/generate_compile_commands.sh
@@ -2,7 +2,7 @@
 
 PACKAGES=""
 CMAKE_ARGS="-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"
-OUTPUT_DIR="~/.devcontainer"
+OUTPUT_DIR="$HOME/.devcontainer"
 TIMEOUT=30
 
 HELP_MESSAGE="
@@ -13,6 +13,7 @@ Generate compile commands for clangd. The following options are supported:
   -p|--packages <packages>  The ROS packages to build (space-separated).
   --cmake-args <args>       Additional CMake arguments (space-separated).
   -t|--timeout <seconds>    Timeout in seconds (default: 30).
+  -o|--output-dir <dir>     Directory to save the compile_commands.json file (default: $OUTPUT_DIR).
   -h|--help                 Show this help message.
 "
 


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

- #132 

<!-- Required: explain how the PR addresses the parent issue -->
I unfortunately used `~` instead of `$HOME` which will not be resolved when inside a string. When using `-o ~/.devcontainer` that would work because the `~` is resolved before it gets into the script

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 1 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [ ] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->