### PR TITLE
fix: properly check for onnxruntime version

### DIFF
--- a/toolkits/Dockerfile.ml
+++ b/toolkits/Dockerfile.ml
@@ -8,6 +8,8 @@ ARG TENSORRT_IMAGE=nvcr.io/nvidia/tensorrt
 
 ARG CUDA_TOOLKIT_VARIANT
 
+ARG ONNX_RUNTIME_VERSION=v1.22.2
+
 FROM python:${PYTHON_VERSION}-slim AS python-builder
 
 ARG TARGET=cpu
@@ -89,7 +91,7 @@ RUN cp -r /opt/apt_root/usr/include .
 
 FROM ubuntu:${UBUNTU_VERSION} AS cpp-source
 
-ARG ONNX_RUNTIME_VERSION=v1.22.2
+ARG ONNX_RUNTIME_VERSION
 RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     ca-certificates \
@@ -104,6 +106,7 @@ FROM ubuntu:${UBUNTU_VERSION} AS cpu-builder
 ARG CPP_DEPS
 ARG PY_DEPS
 ARG ONNX_BUILD_PARALLEL
+ARG ONNX_RUNTIME_VERSION
 
 RUN apt-get update \
  && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -139,9 +142,9 @@ RUN set -eux; \
     fi; \
     # no longer available after version 1.22.0
     # ! this does not check for the lower bound version when this argument was introduced
-    if [ "$(echo ${ONNX_RUNTIME_VERSION} | cut -d. -f1)" -lt 1 ] || \
-       { [ "$(echo ${ONNX_RUNTIME_VERSION} | cut -d. -f1)" -eq 1 ] && \
-         [ "$(echo ${ONNX_RUNTIME_VERSION} | cut -d. -f2)" -lt 22 ]; }; then \
+    if [ "$(echo ${ONNX_RUNTIME_VERSION#v} | cut -d. -f1)" -lt 1 ] || \
+       { [ "$(echo ${ONNX_RUNTIME_VERSION#v} | cut -d. -f1)" -eq 1 ] && \
+         [ "$(echo ${ONNX_RUNTIME_VERSION#v} | cut -d. -f2)" -lt 22 ]; }; then \
       build_extra="$build_extra --use_preinstalled_eigen --eigen_path=/usr/include/eigen3"; \
     fi; \
     ./build.sh \
@@ -171,6 +174,7 @@ ARG PYTHON_VERSION
 ARG CUDA_ARCHS=""
 ARG ONNX_BUILD_PARALLEL
 ARG ONNX_BUILD_FOR_GPU=1
+ARG ONNX_RUNTIME_VERSION
 ARG TARGET
 
 ENV EXTRA_APT_PKGS=""
@@ -232,9 +236,9 @@ RUN set -eux; \
     fi; \
     # no longer available after version 1.22.0
     # ! this does not check for the lower bound version when this argument was introduced
-    if [ "$(echo ${ONNX_RUNTIME_VERSION} | cut -d. -f1)" -lt 1 ] || \
-       { [ "$(echo ${ONNX_RUNTIME_VERSION} | cut -d. -f1)" -eq 1 ] && \
-         [ "$(echo ${ONNX_RUNTIME_VERSION} | cut -d. -f2)" -lt 22 ]; }; then \
+    if [ "$(echo ${ONNX_RUNTIME_VERSION#v} | cut -d. -f1)" -lt 1 ] || \
+       { [ "$(echo ${ONNX_RUNTIME_VERSION#v} | cut -d. -f1)" -eq 1 ] && \
+         [ "$(echo ${ONNX_RUNTIME_VERSION#v} | cut -d. -f2)" -lt 22 ]; }; then \
       build_extra="$build_extra --use_preinstalled_eigen --eigen_path=/usr/include/eigen3"; \
     fi; \
     ./build.sh \


### PR DESCRIPTION
<!-- Pull Request guidelines:
1. Give the PR a relevant and descriptive title, using one of the supported commit types:
   [ build, ci, chore, docs, feat, fix, perf, refactor, release, revert, style, test ]
2. Link the PR to the parent issue, which should already describe and motivate the PR
3. Explain how the PR addresses the parent issue
4. Add any supporting resources (screenshots, test results, etc)
5. Help the reviewer by suggesting the method and estimated time to review
6. If applicable, make a checklist of tasks that should be completed before merging
7. If applicable, mention related issues (blocked by / blocks)
8. Post creation actions: tag reviewers and link the PR to its parent issue under the Development section
-->

## Description

<!-- Required: link the parent issue -->

- n/a

<!-- Required: explain how the PR addresses the parent issue -->
Another small omission which was not applicable to images that default to onnxruntime 1.22+. So, basically it showed up on the jetson build and I probably missed it due to caching at some point. Nothing functional changes, just properly checking versions.

<!-- Optional: add additional resources (links, screenshots, test results, etc)
## Supporting information
-->

## Review guidelines

<!-- Required: estimate how long a review should take -->
Estimated Time of Review: 2 minutes

<!-- Optional: provide more suggestions such as "Review by commit", "Read this documentation first", etc -->

## Checklist before merging:

- [x] Confirm that the relevant changelog(s) are up-to-date in case of any user-facing changes

<!-- Optional: define further tasks that should be completed before merging
- [x] Task 1
- [ ] Task 2
-->

<!-- Optional: link related issues
## Related issues
### Blocked by:
- #0

### Blocks:
- #0
-->